### PR TITLE
specify types in test where inference fails

### DIFF
--- a/src/components/atoms/title/title.test.tsx
+++ b/src/components/atoms/title/title.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { Title } from './title';
+import { Content } from '../../../types/content';
 
 describe('Title', () => {
   it('should render the title with a string passed into the title prop', () => {
@@ -10,21 +11,21 @@ describe('Title', () => {
   });
 
   it('should render the title with a array of strings passed into the title prop', () => { // whitespace issues
-    const titles = ['This', 'is', 'a', 'title'];
+    const titles: Content = ['This', 'is', 'a', 'title'];
     render(<Title title={titles}/>);
 
     expect(screen.getByText('Thisisatitle')).toBeInTheDocument();
   });
 
   it('should render the title with a single content part passed into the title prop', () => {
-    const title = { type: 'Strong', content: 'This is a title' };
+    const title: Content = { type: 'Strong', content: 'This is a title' };
     render(<Title title={title}/>);
 
     expect(screen.getByText('This is a title')).toBeInTheDocument();
   });
 
   it('should render the title with an array of content parts passed into the title prop', () => { // whitespace issues
-    const title = [{ type: 'Strong', content: 'This is a' }, { type: 'Emphasis', content: 'title' }];
+    const title: Content = [{ type: 'Strong', content: 'This is a' }, { type: 'Emphasis', content: 'title' }];
     render(<Title title={title}/>);
 
     expect(screen.getByText('This is a')).toBeInTheDocument();
@@ -32,7 +33,7 @@ describe('Title', () => {
   });
 
   it('should render the title with an array of content parts and strings passed into the title prop', () => { // components in a list need a key
-    const title = [{ type: 'Strong', content: 'This is a' }, 'title'];
+    const title: Content = [{ type: 'Strong', content: 'This is a' }, 'title'];
     render(<Title title={title}/>);
 
     expect(screen.getByText('This is a')).toBeInTheDocument();
@@ -40,14 +41,14 @@ describe('Title', () => {
   });
 
   it('should render the title with a nested string array in a content part passed into the title prop', () => { // components in a list need a key
-    const title = [{ type: 'Strong', content: ['This', 'is', 'a', 'title'] }];
+    const title: Content = [{ type: 'Strong', content: ['This', 'is', 'a', 'title'] }];
     render(<Title title={title}/>);
 
     expect(screen.getByText('Thisisatitle')).toBeInTheDocument();
   });
 
   it('should render the title with a doubly nested content part passed into the title prop', () => { // components in a list need a key
-    const title = [{ type: 'Strong', content: { type: 'Emphasis', content: 'This is a title' } }];
+    const title: Content = [{ type: 'Strong', content: { type: 'Emphasis', content: 'This is a title' } }];
     render(<Title title={title}/>);
     const titleElement = screen.getByText('This is a title');
 


### PR DESCRIPTION
tsc could not resolve types in the title tests so they have been specified to allow the build to run