### PR TITLE
Refine the content types based on the mockContent data.

### DIFF
--- a/src/components/atoms/article-content/article-content.stories.tsx
+++ b/src/components/atoms/article-content/article-content.stories.tsx
@@ -12,6 +12,5 @@ const Template: ComponentStory<typeof ArticleContent> = (args) => <ArticleConten
 
 export const Article = Template.bind({});
 Article.args = {
-// @ts-ignore
   content: mockContent,
 };

--- a/src/components/atoms/article-content/mock-content.ts
+++ b/src/components/atoms/article-content/mock-content.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
+import { Content } from '../../../types/content';
 
-export const mockContent = [
+export const mockContent: Content = [
   {
     type: 'Heading',
     id: 's1',

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -17,6 +17,7 @@ type DateContent = DecoratedContent & {
 type LinkContent = DecoratedContent & {
   type: 'Link',
   target: string,
+  relation?: string,
 };
 
 type CiteContent = DecoratedContent & {
@@ -37,9 +38,10 @@ type FigureContent = DecoratedContent & {
   label: string,
 };
 
-type ImageObjectContent = DecoratedContent & {
+type ImageObjectContent = {
   type: 'ImageObject',
-  contentUrl: string,
+  contentUrl?: string,
+  content?: Content
   meta: {
     inline: boolean,
   },
@@ -71,4 +73,4 @@ type ContentPart =
   FigureContent |
   ImageObjectContent;
 
-export type Content = string | ContentPart | Array<ContentPart>;
+export type Content = ContentPart | Array<ContentPart>;


### PR DESCRIPTION
Being explicit with the mockData const type showed some further issues with our typing:
- `ImageObject` has optional content and contentUrl properties
- `Link` has an optional relation property

We can now also remove @ts-ignore from `article-content.stories.tsx`

One for @will-byrne to review 