### PR TITLE
Fix citations needing to be in brackets

### DIFF
--- a/src/utils/content-to-jsx.test.tsx
+++ b/src/utils/content-to-jsx.test.tsx
@@ -32,7 +32,7 @@ describe('Content to JSX', () => {
       target: 'target',
     });
 
-    expect(result).toStrictEqual(<a href={'target'}>I am a citation</a>);
+    expect(result).toStrictEqual(<>(<a href={'target'}>I am a citation</a>)</>);
   });
 
   it('generates the expected html when passed a Link', () => {

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -21,6 +21,7 @@ export const contentToJsx = (content: Content, index?: number): JSXContent => {
     case 'Heading':
       return <Heading id={content.id} content={content.content} headingLevel={content.depth}/>;
     case 'Cite':
+      return <>(<a key={index} href={content.target}>{contentToJsx(content.content)}</a>)</>;
     case 'Link':
       return <a key={index} href={content.target}>{contentToJsx(content.content)}</a>;
     case 'Paragraph':


### PR DESCRIPTION
Because it's quick and needed for launch (talked about in cross-functional discussion)