### PR TITLE
Fix routing for journal proxying

### DIFF
--- a/.storybook/fix-next-image.js
+++ b/.storybook/fix-next-image.js
@@ -1,0 +1,13 @@
+import * as NextImage from "next/image";
+
+const OriginalNextImage = NextImage.default;
+
+Object.defineProperty(NextImage, "default", {
+  configurable: true,
+  value: (props) => (
+    <OriginalNextImage
+      {...props}
+      unoptimized
+    />
+  ),
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,16 +11,4 @@ export const parameters = {
   },
 }
 
-import * as NextImage from "next/image";
-
-const OriginalNextImage = NextImage.default;
-
-Object.defineProperty(NextImage, "default", {
-  configurable: true,
-  value: (props) => (
-    <OriginalNextImage
-      {...props}
-      unoptimized
-    />
-  ),
-});
+import './fix-next-image';

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   rewrites: async () => ({
     beforeFiles: [
       {
-        source: '/:msid(\\d+)',
+        source: '/:msid(\\d+v{0,1}\\d*)',
         destination: '/reviewed-preprints/:msid',
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -2,10 +2,23 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  rewrites: () => [
-  ],
+  rewrites: async () => ({
+    beforeFiles: [
+      {
+        source: '/:msid(\\d+)',
+        destination: '/reviewed-preprints/:msid',
+      },
+      {
+        source: '/reviewed-preprints/_next/:path*',
+        destination: '/_next/:path*',
+      },
+      {
+        source: '/reviewed-preprints/:path([^\\d]+)',
+        destination: '/:path*',
+      },
+    ],
+  }),
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
-  basePath: '/reviewed-preprints',
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,7 @@ const nextConfig = {
     ],
   }),
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+  assetPrefix: process.env.ASSET_PREFIX ?? '',
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const nextConfig = {
         destination: '/_next/:path*',
       },
       {
-        source: '/reviewed-preprints/:path([^\\d]+)',
+        source: '/reviewed-preprints/:path((?!\\d+v{0,1}\\d*))',
         destination: '/:path*',
       },
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   rewrites: () => [
   ],
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+  basePath: '/reviewed-preprints',
 }
 
 module.exports = nextConfig

--- a/src/components/molecules/site-header/site-header.tsx
+++ b/src/components/molecules/site-header/site-header.tsx
@@ -5,7 +5,7 @@ export const SiteHeader = (): JSX.Element => (
   <div className="site-header">
     <Image
       className={styles['site-header__logo']}
-      src="/elife-logo.svg"
+      src="/reviewed-preprints/elife-logo.svg"
         alt="eLife logo"
         width="80"
         height="30"

--- a/src/components/molecules/site-header/site-header.tsx
+++ b/src/components/molecules/site-header/site-header.tsx
@@ -1,11 +1,12 @@
 import Image from 'next/image';
 import styles from './site-header.module.scss';
+import logo from '../../../../public/elife-logo.svg';
 
 export const SiteHeader = (): JSX.Element => (
   <div className="site-header">
     <Image
       className={styles['site-header__logo']}
-      src="/reviewed-preprints/elife-logo.svg"
+        src={logo}
         alt="eLife logo"
         width="80"
         height="30"

--- a/src/components/molecules/site-header/site-header.tsx
+++ b/src/components/molecules/site-header/site-header.tsx
@@ -6,10 +6,10 @@ export const SiteHeader = (): JSX.Element => (
   <div className="site-header">
     <Image
       className={styles['site-header__logo']}
-        src={logo}
-        alt="eLife logo"
-        width="80"
-        height="30"
-      />
+      src={logo}
+      alt="eLife logo"
+      width="80"
+      height="30"
+    />
   </div>
 );

--- a/src/pages/[msid].page.tsx
+++ b/src/pages/[msid].page.tsx
@@ -4,10 +4,10 @@ import {
   ArticlePageProps,
   ArticleStatusProps,
   PeerReviewProps,
-} from '../../components/pages/article/article-page';
-import { config } from '../../config';
-import { manuscripts } from '../../manuscripts';
-import { Content } from '../../types/content';
+} from '../components/pages/article/article-page';
+import { config } from '../config';
+import { manuscripts } from '../manuscripts';
+import { Content } from '../types/content';
 
 export const Page = (props: { metaData: ArticlePageProps, abstract: Content, content: Content, status: ArticleStatusProps, peerReview: PeerReviewProps }): JSX.Element => (
   <ArticlePage {...props}></ArticlePage>
@@ -36,9 +36,9 @@ export const getServerSideProps: GetServerSideProps = async (context: GetServerS
   const { preprintDoi } = manuscriptConfig;
 
   const [metaData, content, peerReview, status] = await Promise.all([
-    await fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/metadata`).then((res) => res.json()),
-    await fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/content`).then((res) => res.json()),
-    await fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/reviews`).then((res) => res.json()),
+    fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/metadata`).then((res) => res.json()),
+    fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/content`).then((res) => res.json()),
+    fetch(`${config.apiServer}/api/reviewed-preprints/${preprintDoi}/reviews`).then((res) => res.json()),
     // replace with call for data
     manuscripts[msid].status,
   ]);

--- a/src/pages/reviewed-preprints/[msid].page.tsx
+++ b/src/pages/reviewed-preprints/[msid].page.tsx
@@ -4,10 +4,10 @@ import {
   ArticlePageProps,
   ArticleStatusProps,
   PeerReviewProps,
-} from '../components/pages/article/article-page';
-import { config } from '../config';
-import { manuscripts } from '../manuscripts';
-import { Content } from '../types/content';
+} from '../../components/pages/article/article-page';
+import { config } from '../../config';
+import { manuscripts } from '../../manuscripts';
+import { Content } from '../../types/content';
 
 export const Page = (props: { metaData: ArticlePageProps, abstract: Content, content: Content, status: ArticleStatusProps, peerReview: PeerReviewProps }): JSX.Element => (
   <ArticlePage {...props}></ArticlePage>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import '../.storybook/fix-next-image';


### PR DESCRIPTION
To allow clean proxy behaviour, we tell nextjs to publish all content at `/reviewed-preprints`. We then change the main page route to be from the basePath so that /reviewed-preprints/12345 still resolves. 

~This change does mean `/` can no longer route from epp client and will result in a 404 or 5xx on the EPP system url (i.e. not through journal).~

I came up with a better way that redirects wayward requests to the correct place, and allows us to prefix assets in prod to the journal Url. 

This whole journal integration will need a look at again after launch, but this will at least work in a non-journal specific way.