### PR TITLE
fix the size of funder images 

### DIFF
--- a/src/components/atoms/investors/investors.tsx
+++ b/src/components/atoms/investors/investors.tsx
@@ -13,8 +13,8 @@ export const Investors = (): JSX.Element => (
           className={styles['investor-logos__img']}
           src={hhmi}
           alt="Howard Hughes Medical Institute"
-          width="606"
-          height="100"
+          width="185"
+          height="30"
         />
       </div>
     </li>
@@ -35,8 +35,8 @@ export const Investors = (): JSX.Element => (
           className={styles['investor-logos__img']}
           src={max}
           alt="Max-Planck-Gesellschaft"
-          width="280"
-          height="84"
+          width="185"
+          height="55"
         />
       </div>
     </li>

--- a/src/components/atoms/investors/investors.tsx
+++ b/src/components/atoms/investors/investors.tsx
@@ -46,8 +46,8 @@ export const Investors = (): JSX.Element => (
           className={styles['investor-logos__img']}
           src={kaw}
           alt="Knut and Alice Wallenberg Foundation"
-          width="128"
-          height="74"
+          width="125"
+          height="72"
         />
       </div>
     </li>


### PR DESCRIPTION
The sizes set in the next/image object are for producing optimized images for mobile and HiDPI screens. This needs to be the target height for display in page - what we want it to be.

This PR sets the next/image component width/height at the appropriate ratio adjusted width in ratio to the height set by other logos. This fixes issues with oversized images rendering when there is a CSS failure.