### PR TITLE
fix docker-compose: run 'yarn' with node_modules mounted to repopulate on every startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,6 +125,9 @@ services:
     build:
       context: .
       target: storybook
+    depends_on:
+      yarn:
+        condition: service_completed_successfully
     ports:
     - "6006:6006"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -90,6 +90,14 @@ services:
       - import_data:/tmp/git
 
   # Main app server
+  yarn:
+    build:
+      context: .
+      target: dev
+    command: yarn
+    volumes:
+    - ./:/opt/epp-client/
+    - node_modules:/opt/epp-client/node_modules
   app:
     build:
       context: .
@@ -103,6 +111,9 @@ services:
     environment:
       API_SERVER: http://api:3000
       NEXT_PUBLIC_IMAGE_SERVER: /iiif
+    depends_on:
+      yarn:
+        condition: service_completed_successfully
     ports:
     - 3001:3000
     volumes:


### PR DESCRIPTION
fix: node_modules volume doesn't get repopulated on first boot, and also can get stale. run 'yarn' with node_modules mounted to repopulate on every startup.

This caused hard to diagnose differences between local and prod