### PR TITLE
fix issue with placement of next/title prerendering in the wrong place

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,10 +1,16 @@
 
+import Head from 'next/head';
 import { DefaultLayout } from '../components/layouts/default';
 
 export default function MyApp({ Component, pageProps }: any) {
   return (
+    <>
+    <Head>
+      <title>Enhanced Preprints Platform</title>
+    </Head>
     <DefaultLayout>
       <Component {...pageProps} />
     </DefaultLayout>
+    </>
   );
 }

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -39,7 +39,6 @@ export default function Document() {
             })(window,document,'script','dataLayer','${config.gtmId}');`,
           }}></script>
         }
-        <title>Enhanced Preprints Platform</title>
       </Head>
       <body>
         { config.gtmId &&


### PR DESCRIPTION
```
Warning: <title> should not be used in _document.js's <Head>. https://nextjs.org/docs/messages/no-document-title
```