### PR TITLE
fix healthcheck when running in prod-mode as the build needs more time than a dev server run

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -2,3 +2,9 @@
 services:
   app:
     command: sh -c 'yarn build; yarn start'
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'apk add curl; curl -X POST http://app:3000/'"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s


### PR DESCRIPTION
I think this might also be a fix for @discodavey 's issue with running `make start-prod`. For me locally this resolves an issue waiting for the app service to be healthy.