### PR TITLE
Improve error logging during jsonFetch

### DIFF
--- a/src/utils/json-fetch.ts
+++ b/src/utils/json-fetch.ts
@@ -1,7 +1,7 @@
 export const jsonFetch = <T>(url: string): Promise<T> => fetch(url)
   .then((response) => {
     if (!response.ok) {
-      throw new Error(response.statusText);
+      throw new Error(`error fetching (${url}): ${response.statusText}`);
     }
     return response.json() as Promise<T>;
   });


### PR DESCRIPTION
I added this locally when I hit an issue and I needed to know which of the fetches was failing.