### PR TITLE
Refactor modal to improve styles and remove trigger from template

### DIFF
--- a/src/components/atoms/modal/modal.scss
+++ b/src/components/atoms/modal/modal.scss
@@ -13,6 +13,9 @@
 }
 
 .modal-content {
+  @include mixins.margin(0);
+  @include mixins.padding(36);
+
   background-color: #fff;
   border-radius: 3px;
   box-shadow: 0 0 20px rgb(0 0 0 / 22%);
@@ -22,29 +25,48 @@
   padding: 36px;
 
   @media only all and (min-width: settings.$breakpoint-small) {
-    margin: 24px;
+    @include mixins.margin(24);
   }
 
   @media only all and (min-width: settings.$breakpoint-medium) {
-    margin: 180px auto 24px;
+    @include mixins.margin(180, "top");
+    @include mixins.margin(auto, "right");
+    @include mixins.margin(24, "top");
+
     max-width: 730px;
   }
 
   h6 {
     @include mixins.margin(0);
-    @include mixins.padding(10 0 14);
+    @include mixins.padding(0 0 12);
     @include typography.font-size-and-vertical-height(16,24);
 
-    grid-column: 1/3;
+    grid-column: 1/6;
     grid-row: 1;
     justify-self: start;
-    padding-top: 0;
   }
 }
 
 .modal-content__body {
   display: grid;
-  grid-column: 1/3;
+  grid-column: 1/6;
+}
+
+.modal-content__block {
+  grid-column: 1/6;
+}
+
+.modal-content__top {
+  @include mixins.padding(24, "bottom");
+
+  display: grid;
+}
+
+.modal-content__title {
+  @include mixins.padding(0);
+
+  grid-column: 2/4;
+  grid-row: 1;
 }
 
 .modal-content__show {
@@ -56,14 +78,16 @@
 
 .modal-content__close-button {
   @include mixins.padding(0 25 0 0);
+  @include typography.font-size-and-vertical-height(16, 24);
 
-  background: url("../../../images/actions/close.svg") right 4px no-repeat;
+  align-self: start;
+  background: url("../../../images/actions/close.svg") right 5px no-repeat;
   border: none;
   color: settings.$color-text;
   cursor: pointer;
   font-family: settings.$font-family-primary;
   font-weight: bold;
-  grid-column: 2/3;
+  grid-row: 1;
   height: auto;
   justify-self: end;
   z-index: 2000;

--- a/src/components/atoms/modal/modal.scss
+++ b/src/components/atoms/modal/modal.scss
@@ -30,16 +30,17 @@
 
   @media only all and (min-width: settings.$breakpoint-medium) {
     @include mixins.margin(180, "top");
-    @include mixins.margin(auto, "right");
-    @include mixins.margin(24, "top");
+    @include mixins.margin(24, "bottom");
 
+    margin-left: auto;
+    margin-right: auto;
     max-width: 730px;
   }
 
   h6 {
     @include mixins.margin(0);
     @include mixins.padding(0 0 12);
-    @include typography.font-size-and-vertical-height(16,24);
+    @include typography.font-size-and-vertical-height(16, 24);
 
     grid-column: 1/6;
     grid-row: 1;

--- a/src/components/atoms/modal/modal.stories.tsx
+++ b/src/components/atoms/modal/modal.stories.tsx
@@ -1,17 +1,27 @@
+import {
+  useState,
+} from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Modal } from './modal';
 
 export default {
-  title: 'Atoms/ Modal',
+  title: 'Atoms/Modal',
   component: Modal,
 } as ComponentMeta<typeof Modal>;
 
-const Template: ComponentStory<typeof Modal> = (args) => (
-  <Modal {...args} />
-);
+const Template: ComponentStory<typeof Modal> = (args) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => { setShowModal(true); }}>Modal Link</button>
+      <Modal {...args} open={showModal} onModalClose={() => { setShowModal(false); }} />
+    </>
+  );
+};
 
 export const ModalContainer = Template.bind({});
 ModalContainer.args = {
   modalTitle: 'This is a title',
-  modalContent: 'This is some content',
+  children: (<>This is content</>),
 };

--- a/src/components/atoms/modal/modal.test.tsx
+++ b/src/components/atoms/modal/modal.test.tsx
@@ -20,7 +20,7 @@ describe('Modal window', () => {
     expect(screen.getByText('This is the content').parentElement?.parentElement?.parentElement).toHaveClass('modal-content__show');
   });
 
-  it('displays a close button if onModalClose not set', () => {
+  it('only displays a close button if onModalClose set', () => {
     render(<Modal modalTitle='This is the title' open={true}>This is the content</Modal>);
 
     expect(screen.queryByText('Close', { exact: false })).not.toBeInTheDocument();

--- a/src/components/atoms/modal/modal.test.tsx
+++ b/src/components/atoms/modal/modal.test.tsx
@@ -2,40 +2,46 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { Modal } from './modal';
 
 describe('Modal window', () => {
-  it('button shows', () => {
-    render(<Modal modalTitle='This is the title' modalContent='This is the content' />);
-
-    expect(screen.getByText('Modal Link')).toBeInTheDocument();
-  });
-
   it('does not show', () => {
-    render(<Modal modalTitle='This is the title' modalContent='This is the content' />);
+    render(<Modal modalTitle='This is the title'>This is the content</Modal>);
 
-    expect(screen.getByText('This is the content').parentElement?.parentElement).not.toHaveClass('modal-content__show');
+    expect(screen.getByText('This is the content').parentElement?.parentElement?.parentElement).not.toHaveClass('modal-content__show');
   });
 
-  it('shows on click', () => {
-    render(<Modal modalTitle='This is the title' modalContent='This is the content' />);
-    expect(screen.getByText('This is the content').parentElement?.parentElement).not.toHaveClass('modal-content__show');
+  it('is hidden when open set to false', () => {
+    render(<Modal modalTitle='This is the title' open={false}>This is the content</Modal>);
 
-    const showModalBlock = screen.getByText('modal link', { exact: false });
-    fireEvent.click(showModalBlock);
-
-    expect(screen.getByText('This is the content').parentElement?.parentElement).toHaveClass('modal-content__show');
+    expect(screen.getByText('This is the content').parentElement?.parentElement?.parentElement).not.toHaveClass('modal-content__show');
   });
 
-  it('hides on click', () => {
-    render(<Modal modalTitle='This is the title' modalContent='This is the content' />);
-    expect(screen.getByText('This is the content').parentElement?.parentElement).not.toHaveClass('modal-content__show');
+  it('is shown when open set to true', () => {
+    render(<Modal modalTitle='This is the title' open={true}>This is the content</Modal>);
 
-    const showModalBlock = screen.getByText('modal link', { exact: false });
-    fireEvent.click(showModalBlock);
+    expect(screen.getByText('This is the content').parentElement?.parentElement?.parentElement).toHaveClass('modal-content__show');
+  });
 
-    expect(screen.getByText('This is the content').parentElement?.parentElement).toHaveClass('modal-content__show');
+  it('displays a close button if onModalClose not set', () => {
+    render(<Modal modalTitle='This is the title' open={true}>This is the content</Modal>);
 
-    const hideModalBlock = screen.getByText('modal link', { exact: false });
+    expect(screen.queryByText('Close', { exact: false })).not.toBeInTheDocument();
+
+    render(<Modal modalTitle='This is the title' open={true} onModalClose={() => {}}>This is the content</Modal>);
+
+    expect(screen.queryByText('Close', { exact: false })).toBeInTheDocument();
+  });
+
+  it('runs onModalClose function', () => {
+    let onModalCloseIndicator = false;
+    render(<Modal modalTitle='This is the title' open={true} onModalClose={() => {
+      onModalCloseIndicator = true;
+    }}>This is the content</Modal>);
+    expect(screen.getByText('This is the content').parentElement?.parentElement?.parentElement).toHaveClass('modal-content__show');
+
+    expect(onModalCloseIndicator).toStrictEqual(false);
+
+    const hideModalBlock = screen.getByText('Close', { exact: false });
     fireEvent.click(hideModalBlock);
 
-    expect(screen.getByText('This is the content').parentElement?.parentElement).not.toHaveClass('modal-content__show');
+    expect(onModalCloseIndicator).toStrictEqual(true);
   });
 });

--- a/src/components/atoms/modal/modal.tsx
+++ b/src/components/atoms/modal/modal.tsx
@@ -22,7 +22,7 @@ export const Modal = ({
 
   return (
   <>
-    <div onClick={(event) => { if (onModalClose !== undefined && clickDetectedOutsideOfModal(event)) { onModalClose(); } }} className={`modal-container${open ? ' modal-content__show' : ''} `}>
+    <div onClick={(event) => { onModalClose !== undefined && clickDetectedOutsideOfModal(event) && onModalClose(); }} className={`modal-container${open ? ' modal-content__show' : ''} `}>
       <div ref={contentRef} className="modal-content">
         <div className="modal-content__block">
           <div className="modal-content__top">

--- a/src/components/atoms/modal/modal.tsx
+++ b/src/components/atoms/modal/modal.tsx
@@ -22,7 +22,7 @@ export const Modal = ({
 
   return (
   <>
-    <div onClick={(event) => { onModalClose !== undefined && clickDetectedOutsideOfModal(event) && onModalClose(); }} className={`modal-container${open ? ' modal-content__show' : ''} `}>
+    <div onClick={(event) => { if (onModalClose !== undefined && clickDetectedOutsideOfModal(event)) { onModalClose(); } }} className={`modal-container${open ? ' modal-content__show' : ''} `}>
       <div ref={contentRef} className="modal-content">
         <div className="modal-content__block">
           <div className="modal-content__top">

--- a/src/components/atoms/modal/modal.tsx
+++ b/src/components/atoms/modal/modal.tsx
@@ -1,30 +1,34 @@
-import { useRef, useState, MouseEvent } from 'react';
+import {
+  useRef, MouseEvent,
+} from 'react';
 import './modal.scss';
 
 type Props = {
-  modalTitle: string, modalContent: string
+  modalTitle: string,
+  children?: React.ReactNode,
+  open?: boolean,
+  onModalClose?: () => void,
 };
 
-export const Modal = ({ modalTitle, modalContent }: Props): JSX.Element => {
-  const [showModal, setShowModal] = useState(false);
+export const Modal = ({ modalTitle, children, open = false, onModalClose, }: Props): JSX.Element => {
   const contentRef = useRef<HTMLDivElement>(null);
-  const closeModal = () => setShowModal(false);
 
   const clickHandler = (event: MouseEvent<HTMLDivElement>) => {
-    if (contentRef.current && !contentRef.current.contains(event.target as Element)) {
-      closeModal();
+    if (onModalClose !== undefined && contentRef.current && !contentRef.current.contains(event.target as Element)) {
+      onModalClose();
     }
   };
 
   return (
   <>
-    <button className="modal-button" onClick={() => setShowModal(!showModal)}>Modal Link</button>
-    <div onClick={(event) => clickHandler(event)} className={`modal-container${showModal ? ' modal-content__show' : ''} `}>
+    <div onClick={(event) => clickHandler(event)} className={`modal-container${open ? ' modal-content__show' : ''} `}>
       <div ref={contentRef} className="modal-content">
-        <button className="modal-content__close-button" onClick={closeModal}>Close</button>
         <div className="modal-content__block">
-          <h6>{modalTitle}</h6>
-          {modalContent}
+          <div className="modal-content__top">
+            <h6 className="modal-content__title">{modalTitle}</h6>
+            {onModalClose !== undefined ? (<button className="modal-content__close-button" onClick={onModalClose}>Close</button>) : ''}
+          </div>
+          {children !== undefined ? (<div className="modal-content__body">{children}</div>) : ''}
         </div>
       </div>
     </div>

--- a/src/components/atoms/modal/modal.tsx
+++ b/src/components/atoms/modal/modal.tsx
@@ -10,18 +10,19 @@ type Props = {
   onModalClose?: () => void,
 };
 
-export const Modal = ({ modalTitle, children, open = false, onModalClose, }: Props): JSX.Element => {
+export const Modal = ({
+  modalTitle,
+  children,
+  open = false,
+  onModalClose,
+}: Props): JSX.Element => {
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const clickHandler = (event: MouseEvent<HTMLDivElement>) => {
-    if (onModalClose !== undefined && contentRef.current && !contentRef.current.contains(event.target as Element)) {
-      onModalClose();
-    }
-  };
+  const clickDetectedOutsideOfModal = (event: MouseEvent<HTMLDivElement>) => contentRef.current && !contentRef.current.contains(event.target as Element);
 
   return (
   <>
-    <div onClick={(event) => clickHandler(event)} className={`modal-container${open ? ' modal-content__show' : ''} `}>
+    <div onClick={(event) => { if (onModalClose !== undefined && clickDetectedOutsideOfModal(event)) { onModalClose(); } }} className={`modal-container${open ? ' modal-content__show' : ''} `}>
       <div ref={contentRef} className="modal-content">
         <div className="modal-content__block">
           <div className="modal-content__top">


### PR DESCRIPTION
This progresses the modal component in the following ways:

- improves the styling to ensure that the close button is inline with the title matching designs.
- ensures that there is no trigger for opening the modal within the modal component but provides an example (with tests) on how the trigger behaviour can be assigned to an element in the DOM.
- will simplify the [PR for the share modal](https://github.com/elifesciences/enhanced-preprints-client/pull/310)