### PR TITLE
Start building images tagged with pr_id, and only post Preview URL if  detected 200 status code

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -32,13 +32,13 @@ jobs:
           target: prod
           load: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }}
       - name: run test
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn test --ci --watchAll=false
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn test --ci --watchAll=false
       - name: run lint
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn lint
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn lint
       - name: run lint-sass
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn lint-sass
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn lint-sass
       - name: push preview image
         uses: docker/build-push-action@v3
         with:
@@ -46,7 +46,7 @@ jobs:
           target: prod
           push: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }}
       - name: Build and push preview storybook image
         uses: docker/build-push-action@v3
         with:
@@ -54,7 +54,7 @@ jobs:
           target: storybook
           push: true
           tags: |
-            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.ref_name }}
+            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.head_ref }}
       - name: wait for new environment to come online before posting an Env URL
         run: timeout 1800 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://pr-${{ github.event.number }}--epp.elifesciences.org/)" != "200" ]]; do sleep 5; done' || false
       - name: "Update preview status with URL"

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -32,13 +32,13 @@ jobs:
           target: prod
           load: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.sha }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }}
       - name: run test
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.sha }} yarn test --ci --watchAll=false
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn test --ci --watchAll=false
       - name: run lint
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.sha }} yarn lint
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn lint
       - name: run lint-sass
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.sha }} yarn lint-sass
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }} yarn lint-sass
       - name: push preview image
         uses: docker/build-push-action@v3
         with:
@@ -46,7 +46,7 @@ jobs:
           target: prod
           push: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.sha }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.ref_name }}
       - name: Build and push preview storybook image
         uses: docker/build-push-action@v3
         with:
@@ -54,7 +54,9 @@ jobs:
           target: storybook
           push: true
           tags: |
-            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.sha }}
+            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.ref_name }}
+      - name: wait for new environment to come online before posting an Env URL
+        run: timeout 1800 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://pr-${{ github.event.number }}--epp.elifesciences.org/)" != "200" ]]; do sleep 5; done' || false
       - name: "Update preview status with URL"
         if: ${{ success() }}
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -32,13 +32,13 @@ jobs:
           target: prod
           load: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.event.number }}
       - name: run test
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn test --ci --watchAll=false
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.event.number }} yarn test --ci --watchAll=false
       - name: run lint
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn lint
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.event.number }} yarn lint
       - name: run lint-sass
-        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }} yarn lint-sass
+        run: docker run ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.event.number }} yarn lint-sass
       - name: push preview image
         uses: docker/build-push-action@v3
         with:
@@ -46,7 +46,7 @@ jobs:
           target: prod
           push: true
           tags: |
-            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.head_ref }}
+            ${{ env.CLIENT_IMAGE_REPO }}:preview-${{ github.event.number }}
       - name: Build and push preview storybook image
         uses: docker/build-push-action@v3
         with:
@@ -54,7 +54,7 @@ jobs:
           target: storybook
           push: true
           tags: |
-            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.head_ref }}
+            ${{ env.STORYBOOK_IMAGE_REPO }}:preview-${{ github.event.number }}
       - name: wait for new environment to come online before posting an Env URL
         run: timeout 1800 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' https://pr-${{ github.event.number }}--epp.elifesciences.org/)" != "200" ]]; do sleep 5; done' || false
       - name: "Update preview status with URL"


### PR DESCRIPTION
We recently switch the env build script to post the latest digest instead of relying on the commit hash, and to check for pr_id tag name This switches the image tag to be pr_id, which:
- reduces the number of tags in the CR view
- allows for there to not be a flip/flop when checking for the latest image (we just update the digest instead)
- pr_id is slightly more consistent that the sha, as that changes with pushes to master (without triggering the build).

Finally, we stall the pipeline for 30 mins waiting for the Environment to appear before we publish the Preview Environment. This should also make the developer experience slightly better, rather than having to infer and wait after the env URL is posted.