### PR TITLE
Slim down the EPP-client container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ docker-compose.yaml
 Dockerfile
 Makefile
 .github/**
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 ARG node_version=18.12-alpine3.15
 
-FROM node:${node_version} as base
-RUN mkdir /opt/epp-client
-WORKDIR /opt/epp-client
+FROM node:${node_version} as builder
 COPY package.json package.json
 COPY yarn.lock yarn.lock
 RUN yarn
+
+FROM node:${node_version} as base
+RUN mkdir /opt/epp-client
+WORKDIR /opt/epp-client
+COPY --from=builder /node_modules /opt/epp-client/node_modules
 COPY ./ ./
 
 FROM base as dev


### PR DESCRIPTION
The EPP client container is one of the biggest on the cluster, taking up 3.2GB. To make matters worse - we deploy most of that again for the storybook container.

We can reduce the size considerably by simply ignore newly added data files, and building node_modules in a separate build step and only copying the output