### PR TITLE
change to formatName in reference component

### DIFF
--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -1,7 +1,12 @@
 import { Author, Reference as ReferenceData } from '../../../types';
 import './reference.scss';
 
-const formatName = (author: Author) => `${author.familyNames?.join(' ')} ${author.givenNames?.join(' ')}`;
+const formatName = (author: Author) => {
+  let nameParts: string[] = [];
+  if (author.familyNames) nameParts = [...author.familyNames];
+  if (author.givenNames) nameParts.push(...author.givenNames);
+  return nameParts.join(' ');
+};
 
 export const ReferenceBody = ({ reference, isReferenceList = false }: { reference: ReferenceData, isReferenceList: boolean }): JSX.Element => {
   const referenceJournal = reference.isPartOf?.isPartOf?.name ?? reference.isPartOf?.name;


### PR DESCRIPTION
formatName currently introduces 'undefined' when an object entry is not present due to optional chaining (see example [here](https://prod--epp.elifesciences.org/preview/87008/v1#c58))