### PR TITLE
Add additional nextJS linting plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     project: './tsconfig.json',
   },
   plugins: ['@typescript-eslint', "no-only-tests"],
-  extends: ["airbnb/base", "airbnb-typescript/base", "plugin:react/recommended", "plugin:react/jsx-runtime", "plugin:storybook/recommended", "plugin:json/recommended"],
+  extends: ["airbnb/base", "airbnb-typescript/base", "plugin:react/recommended", "plugin:react/jsx-runtime", "plugin:storybook/recommended", "plugin:json/recommended", "plugin:@next/next/recommended", "plugin:@next/next/core-web-vitals"],
   rules: {
     "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 1 }],
     "import/prefer-default-export": 0,

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     ]
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^13.4.5",
     "@playwright/test": "^1.29.2",
     "@storybook/addon-a11y": "^7.0.6",
     "@storybook/addon-actions": "^7.0.6",

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -4,6 +4,7 @@ import {
   Main,
   NextScript,
 } from 'next/document';
+import Script from 'next/script';
 import { config } from '../config';
 
 export default function Document() {
@@ -26,19 +27,18 @@ export default function Document() {
           `}
         </style>
         { config.cookiebotId &&
-          <script
-            id="Cookiebot"
+          <Script id="Cookiebot"
             src="https://consent.cookiebot.com/uc.js"
-            data-cbid={config.cookiebotId}></script>
+            data-cbid={config.cookiebotId}></Script>
         }
         { config.gtmId &&
-          <script dangerouslySetInnerHTML={{
+          <Script id="GTM" dangerouslySetInnerHTML={{
             __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','${config.gtmId}');`,
-          }}></script>
+          }}></Script>
         }
       </Head>
       <body>

--- a/src/utils/content-to-jsx.test.tsx
+++ b/src/utils/content-to-jsx.test.tsx
@@ -129,6 +129,7 @@ describe('Content to JSX', () => {
       },
     });
 
+    // eslint-disable-next-line @next/next/no-img-element
     expect(result).toStrictEqual(<img loading="lazy" src="https://placekitten.com/500/300"></img>);
   });
 
@@ -142,6 +143,7 @@ describe('Content to JSX', () => {
       },
     });
 
+    // eslint-disable-next-line @next/next/no-img-element
     expect(result).toStrictEqual(<img loading="lazy" className="inline-image" src="https://placekitten.com/500/300"></img>);
   });
 

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -45,6 +45,7 @@ export const contentToJsx = (content: Content, index?: number): JSXContent => {
       if (!content.contentUrl) {
         return '';
       }
+      // eslint-disable-next-line @next/next/no-img-element
       return <img loading="lazy" {...(content.meta.inline ? { className: 'inline-image' } : {})} key={index} src={generateImageUrl(content.contentUrl)}></img>;
     case 'ListItem':
       return <li key={index}>{contentToJsx(content.content)}</li>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2820,6 +2820,13 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.5.tgz#35b126d2af0d6d60ef73e3ef84b089aa1813c0e0"
   integrity sha512-SG/gKH6eij4vwQy87b/3mbpQ1X3x2vUdnpwq6/qL2IQWjtq58EY/UuNAp9CoEZoC9sI4L9AD1r+73Z9r4d3uug==
 
+"@next/eslint-plugin-next@^13.4.5":
+  version "13.4.5"
+  resolved "https://registry.yarnpkg.com/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.5.tgz#c3339748a7d59d80a019cd441453500391610167"
+  integrity sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g==
+  dependencies:
+    glob "7.1.7"
+
 "@next/swc-darwin-arm64@13.4.5":
   version "13.4.5"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz#54eb1fb2521a18e1682214c416cc44f3721dd9c8"
@@ -8742,6 +8749,18 @@ glob-to-regexp@^0.4.0, glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
+glob@7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"


### PR DESCRIPTION
```
- warn The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config
```

This PR "fixes" this.

It also fixes the one linting fail that resulted from this (though there are a few warnings too)