### PR TITLE
Remove brackets from single Cite block

### DIFF
--- a/src/utils/content-to-jsx.test.tsx
+++ b/src/utils/content-to-jsx.test.tsx
@@ -32,7 +32,7 @@ describe('Content to JSX', () => {
       target: 'target',
     });
 
-    expect(result).toStrictEqual(<>(<a href={'#target'}>I am a citation</a>)</>);
+    expect(result).toStrictEqual(<><a href={'#target'}>I am a citation</a></>);
   });
 
   it('generates the expected html when passed a Link', () => {

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -22,7 +22,7 @@ export const contentToJsx = (content: Content, index?: number, maxHeadingLevel?:
     case 'Heading':
       return <Heading key={index} id={content.id} content={content.content} headingLevel={content.depth} maxLevel={maxHeadingLevel}/>;
     case 'Cite':
-      return <Fragment key={index}>(<a href={`#${content.target}`}>{contentToJsx(content.content)}</a>)</Fragment>;
+      return <Fragment key={index}><a href={`#${content.target}`}>{contentToJsx(content.content)}</a></Fragment>;
     case 'CiteGroup':
       return <span key={index}>({content.items.map((citeContent, citeIndex) => <a key={citeIndex} href={`#${citeContent.target}`}>{contentToJsx(citeContent.content)}</a>)})</span>;
     case 'Link':


### PR DESCRIPTION
Needed before we upgrade to Encoda 1.0.0 but we should release shortly after upgrade.