### PR TITLE
move next/script tags to _app

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,6 +1,8 @@
 
 import Head from 'next/head';
+import Script from 'next/script';
 import { DefaultLayout } from '../components/layouts/default';
+import { config } from '../config';
 
 export default function MyApp({ Component, pageProps }: any) {
   return (
@@ -8,6 +10,20 @@ export default function MyApp({ Component, pageProps }: any) {
     <Head>
       <title>Enhanced Preprints Platform</title>
     </Head>
+    { config.cookiebotId &&
+      <Script id="Cookiebot"
+        src="https://consent.cookiebot.com/uc.js"
+        data-cbid={config.cookiebotId}></Script>
+    }
+    { config.gtmId &&
+      <Script id="GTM" dangerouslySetInnerHTML={{
+        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${config.gtmId}');`,
+      }}></Script>
+    }
     <DefaultLayout>
       <Component {...pageProps} />
     </DefaultLayout>

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -4,7 +4,6 @@ import {
   Main,
   NextScript,
 } from 'next/document';
-import Script from 'next/script';
 import { config } from '../config';
 
 export default function Document() {
@@ -26,20 +25,6 @@ export default function Document() {
           }
           `}
         </style>
-        { config.cookiebotId &&
-          <Script id="Cookiebot"
-            src="https://consent.cookiebot.com/uc.js"
-            data-cbid={config.cookiebotId}></Script>
-        }
-        { config.gtmId &&
-          <Script id="GTM" dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','${config.gtmId}');`,
-          }}></Script>
-        }
       </Head>
       <body>
         { config.gtmId &&


### PR DESCRIPTION
Currently broken in prod
Moved it to `_app.page.tsx` because it is not supported in next/head, and breaks if outside next/head in `MyApp` in `_document.page.tsx`