### PR TITLE
fix: remove default value for background_image in button-icon mixin

### DIFF
--- a/src/components/atoms/button/button.scss
+++ b/src/components/atoms/button/button.scss
@@ -56,7 +56,7 @@
   }
 }
 
-@mixin button-icon($background_image: "none", $background_color: var(--color-button)) {
+@mixin button-icon($background_image, $background_color: var(--color-button)) {
   @include mixins.padding(41, "left");
 
   background: url($background_image) $background_color no-repeat 11px 15px;


### PR DESCRIPTION
if we wish to allow a default value of none it should not use the url()

see: https://stackoverflow.com/questions/1161061/css-background-image-urlnone-leading-to-errors-in-apache-log-file