### PR TITLE
feat: Add environment variable fallbacks and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The app is still available at [`localhost:8080`](http://localhost:8080).
 
 NOTE: this does not affect storybook, which runs the same in either prod or dev
 
+## Recreating an issue experienced on production
+
+When we are experiencing an issue in production that results in a kaboom then recreating the issue locally can be a quick and effective way to diagnose the problem. 
+
+`API_SERVER=https://prod--epp.elifesciences.org MANUSCRIPT_CONFIG_FILE=/opt/epp-client/manuscripts.json docker compose up`
+
 # Building
 
 The build system depends on docker, buildx and make. You can build the production ready docker image using the `build-prod-and-push` make target, making sure to pass a IMAGE_REPO_PREFIX var pointing to your own container repository (which will be suffixed with `client`):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,9 +135,9 @@ services:
       retries: 10
       start_period: 2s
     environment:
-      API_SERVER: http://api:3000
+      API_SERVER: ${API_SERVER:-http://api:3000}
       NEXT_PUBLIC_IMAGE_SERVER: /iiif
-      MANUSCRIPT_CONFIG_FILE: /opt/epp-client/data/manuscripts.json
+      MANUSCRIPT_CONFIG_FILE: ${MANUSCRIPT_CONFIG_FILE:-/opt/epp-client/data/manuscripts.json}
     depends_on:
       yarn:
         condition: service_completed_successfully


### PR DESCRIPTION
This commit updates the docker-compose.yaml file to include fallbacks for the API_SERVER and MANUSCRIPT_CONFIG_FILE environment variables. It also updates the README.md file with instructions on how to recreate an issue experienced in production.