### PR TITLE
remove unnecessary jsx typing and allow inference to handle types

### DIFF
--- a/src/components/atoms/abstract/abstract.tsx
+++ b/src/components/atoms/abstract/abstract.tsx
@@ -1,9 +1,8 @@
-import { JSX } from 'react';
 import './abstract.scss';
 import { contentToJsx } from '../../../utils/content-to-jsx';
 import { Content } from '../../../types';
 
-export const Abstract = ({ content }: { content: Content }): JSX.Element => (
+export const Abstract = ({ content }: { content: Content }) => (
   <section className="abstract">
     <h1 id="abstract">Abstract</h1>
     {contentToJsx(content)}

--- a/src/components/atoms/article-content/article-content.tsx
+++ b/src/components/atoms/article-content/article-content.tsx
@@ -1,8 +1,7 @@
-import { JSX } from 'react';
 import './article-content.scss';
 import { contentToJsx } from '../../../utils/content-to-jsx';
 import { Content } from '../../../types';
 
-export const ArticleContent = ({ content }: { content: Content }): JSX.Element => (
+export const ArticleContent = ({ content }: { content: Content }) => (
   <article className="article-body">{contentToJsx(content)}</article>
 );

--- a/src/components/atoms/article-flag/article-flag.tsx
+++ b/src/components/atoms/article-flag/article-flag.tsx
@@ -1,10 +1,9 @@
-import { JSX } from 'react';
 import './article-flag.scss';
 
 type Props = {
   flagText: string, url: string
 };
 
-export const ArticleFlag = ({ flagText, url }: Props): JSX.Element => (
+export const ArticleFlag = ({ flagText, url }: Props) => (
   <a className="article-flag__link" href={url}>{flagText}</a>
 );

--- a/src/components/atoms/authors/authors.tsx
+++ b/src/components/atoms/authors/authors.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import './authors.scss';
 import { Author } from '../../../types';
 import { createAuthorId } from '../../../utils/create-author-id';
@@ -6,7 +6,7 @@ import { createAuthorId } from '../../../utils/create-author-id';
 const authorLimit = 3;
 const authorLimits = [authorLimit, 10];
 
-export const Authors = ({ authors }: { authors: Author[] }): JSX.Element => {
+export const Authors = ({ authors }: { authors: Author[] }) => {
   const [expanded, setExpanded] = useState<boolean | null>(null);
 
   useEffect(() => setExpanded(false), []);

--- a/src/components/atoms/button/button.tsx
+++ b/src/components/atoms/button/button.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import './button.scss';
 import { classNameVariant } from '../../../utils/class-name-variant';
 
@@ -16,7 +15,7 @@ type ButtonProps = {
 
 export const Button = ({
   text, iconName, url, variant, onClick, download,
-}: ButtonProps): JSX.Element => (
+}: ButtonProps) => (
   <a className={`button${classNameVariant(iconName, ' button--icon', '-')}${classNameVariant(variant, ' button')}`} href={url} onClick={onClick} download={download}>
     {text}
   </a>

--- a/src/components/atoms/citation/citation.tsx
+++ b/src/components/atoms/citation/citation.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import { Author } from '../../../types';
 import './citation.scss';
 
@@ -14,7 +13,7 @@ export type CitationData = {
 
 const formatName = (author: Author) => `${author.givenNames?.join(' ')} ${author.familyNames?.join(' ')} `;
 
-export const Citation = ({ citation }: { citation: CitationData }): JSX.Element => (
+export const Citation = ({ citation }: { citation: CitationData }) => (
   <div className="citation">
     <ol className="citation__authors_list">
       {citation.authors.map((author, index) => (

--- a/src/components/atoms/clipboard/clipboard.tsx
+++ b/src/components/atoms/clipboard/clipboard.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import '../button/button.scss';
 import './clipboard.scss';
 
@@ -9,7 +9,7 @@ type ClipboardProps = {
 
 const supportsClipboardAPI = () => (!!navigator.clipboard);
 
-export const Clipboard = ({ text, buttonText = 'Copy to clipboard' }: ClipboardProps): JSX.Element => {
+export const Clipboard = ({ text, buttonText = 'Copy to clipboard' }: ClipboardProps) => {
   const [showButton, setShowButton] = useState<boolean>(false);
   const [copied, setCopied] = useState<boolean>(false);
 

--- a/src/components/atoms/descriptors/descriptors.tsx
+++ b/src/components/atoms/descriptors/descriptors.tsx
@@ -1,7 +1,6 @@
-import { JSX } from 'react';
 import './descriptors.scss';
 
-export const Descriptors = ({ doi }: { doi:string }): JSX.Element => (
+export const Descriptors = ({ doi }: { doi:string }) => (
   <div className="descriptors">
     <ul className="descriptors__identifiers">
       <li className="descriptors__identifier">

--- a/src/components/atoms/editors-and-reviewers/editors-and-reviewers.tsx
+++ b/src/components/atoms/editors-and-reviewers/editors-and-reviewers.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import './editors-and-reviewers.scss';
 
 type Participant = {
@@ -7,7 +6,7 @@ type Participant = {
   institution: string,
 };
 
-export const EditorsAndReviewers = ({ participants }: { participants: Participant[] }): JSX.Element => (
+export const EditorsAndReviewers = ({ participants }: { participants: Participant[] }) => (
   <section className="editors-and-reviewers">
     <h2 className="editors-and-reviewers__header" id="editors-and-reviewers" data-jump-menu-target>Editors</h2>
     <ul className="editors-and-reviewers__list">

--- a/src/components/atoms/error-messages/error-messages.tsx
+++ b/src/components/atoms/error-messages/error-messages.tsx
@@ -1,9 +1,8 @@
-import { JSX } from 'react';
 import './error-messages.scss';
 import Image from 'next/image';
 import MissingImage from '../../../images/errors/404.svg';
 
-export const ErrorMessages = (): JSX.Element => (
+export const ErrorMessages = () => (
   <div className="error-container">
     <Image src={MissingImage} width="64" height="157" alt="We're on it" className="error__icon" />
     <h2 className="error__title">We&apos;re looking into it</h2>

--- a/src/components/atoms/footer-main/footer-main.tsx
+++ b/src/components/atoms/footer-main/footer-main.tsx
@@ -1,11 +1,10 @@
-import { JSX } from 'react';
 import Image from 'next/image';
 import carbonNeutral from '../../../images/logos/carbon-neutral.svg';
 import './footer-main.scss';
 
 /* eslint-disable max-len */
 
-export const FooterMain = (): JSX.Element => (
+export const FooterMain = () => (
   <footer className="site-footer">
 
     <div className="site-footer__container">

--- a/src/components/atoms/institutions/institutions.tsx
+++ b/src/components/atoms/institutions/institutions.tsx
@@ -1,10 +1,10 @@
-import { JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import './institutions.scss';
 import { Institution } from '../../../types';
 
 const institutionLimit = 3;
 
-export const Institutions = ({ institutions }: { institutions: Institution[] }): JSX.Element => {
+export const Institutions = ({ institutions }: { institutions: Institution[] }) => {
   const [expanded, setExpanded] = useState<boolean | null>(null);
 
   useEffect(() => setExpanded(false), []);

--- a/src/components/atoms/investors/investors.tsx
+++ b/src/components/atoms/investors/investors.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import Image from 'next/image';
 import './investors.scss';
 import hhmi from '../../../images/investors/hhmi.svg';
@@ -6,7 +5,7 @@ import wellcome from '../../../images/investors/wellcome.svg';
 import max from '../../../images/investors/max.svg';
 import kaw from '../../../images/investors/kaw.svg';
 
-export const Investors = (): JSX.Element => (
+export const Investors = () => (
   <ol className="investor-logos" role="list" aria-label="eLife is funded by these organisations">
     <li className="investor-logos__item" role="listitem">
       <div className="investor-logos__container">

--- a/src/components/atoms/jump-to-menu/jump-to-menu.tsx
+++ b/src/components/atoms/jump-to-menu/jump-to-menu.tsx
@@ -1,4 +1,4 @@
-import { JSX, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Content } from '../../../types';
 import { contentToJsx } from '../../../utils/content-to-jsx';
 import './jump-to-menu.scss';
@@ -9,7 +9,7 @@ export type Heading = {
   text: Content,
 };
 
-export const JumpToMenu = ({ headings }: { headings: Heading[] }): JSX.Element => {
+export const JumpToMenu = ({ headings }: { headings: Heading[] }) => {
   const [active, setActive] = useState(0);
   const [jumping, setJumping] = useState(false);
 

--- a/src/components/atoms/reference-list/reference-list.tsx
+++ b/src/components/atoms/reference-list/reference-list.tsx
@@ -1,10 +1,9 @@
-import { JSX } from 'react';
 import { Heading } from '../heading/heading';
 import './reference-list.scss';
 import { Reference as ReferenceData } from '../../../types';
 import { Reference } from '../reference/reference';
 
-export const ReferenceList = ({ references }: { references: ReferenceData[] }): JSX.Element => (
+export const ReferenceList = ({ references }: { references: ReferenceData[] }) => (
   <section>
     <Heading id="references" headingLevel={1} content="References" />
     <ul className="reference-list">

--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import { Author, Reference as ReferenceData } from '../../../types';
 import './reference.scss';
 
@@ -9,7 +8,7 @@ type ReferenceBodyProps = {
 
 const formatName = (author: Author) => `${author.familyNames ? author.familyNames?.join(' ') : ''} ${author.givenNames ? author.givenNames?.join(' ') : ''}`.trim();
 
-export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceBodyProps): JSX.Element => {
+export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceBodyProps) => {
   const referenceJournal = reference.isPartOf?.isPartOf?.isPartOf?.name ?? reference.isPartOf?.isPartOf?.name ?? reference.isPartOf?.name;
   const referenceVolume = reference.isPartOf?.isPartOf?.volumeNumber ?? reference.isPartOf?.volumeNumber;
   const doiIdentifier = reference.identifiers?.find((identifier) => identifier.name === 'doi');
@@ -42,7 +41,7 @@ export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceB
   );
 };
 
-export const Reference = ({ reference, isReferenceList = false }: { reference: ReferenceData, isReferenceList: boolean }): JSX.Element => (isReferenceList ?
+export const Reference = ({ reference, isReferenceList = false }: { reference: ReferenceData, isReferenceList: boolean }) => (isReferenceList ?
   <li className="reference" id={reference.id}>{ReferenceBody({ reference, isReferenceList })}</li> :
   <div className="reference" id={reference.id}>{ReferenceBody({ reference, isReferenceList })}</div>
 );

--- a/src/components/atoms/review-content/review-content.tsx
+++ b/src/components/atoms/review-content/review-content.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import Link from 'next/link';
 import './review-content.scss';
 
@@ -11,7 +10,7 @@ const highlightTerms = (content: string): string => content.replaceAll(new RegEx
 type Props = { content: string, isAssessment?: boolean, id?: string, peerReviewUrl?: string };
 export const ReviewContent = ({
   content, isAssessment = false, id = '', peerReviewUrl = undefined,
-}: Props): JSX.Element => {
+}: Props) => {
   const sectionProps: Record<string, string> = {
     className: `review-content${isAssessment ? ' review-content--assessment' : ''}`,
   };

--- a/src/components/atoms/sign-up/sign-up.tsx
+++ b/src/components/atoms/sign-up/sign-up.tsx
@@ -1,8 +1,7 @@
-import { JSX } from 'react';
 import './sign-up.scss';
 import { Button } from '../../atoms/button/button';
 
-export const SignUp = (): JSX.Element => (
+export const SignUp = () => (
   <section className="email-cta">
     <div className="email-cta__container">
       <header className="email-cta__header">

--- a/src/components/atoms/socials/socials.tsx
+++ b/src/components/atoms/socials/socials.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import './socials.scss';
 
 type SocialsProps = {
@@ -8,7 +7,7 @@ type SocialsProps = {
 
 export const Socials = ({
   doi, title,
-}: SocialsProps): JSX.Element => {
+}: SocialsProps) => {
   const doiUrl = `https://doi.org/${doi}`;
   const encodedTitle = encodeURIComponent(title);
   const twitterEncodedTitle = encodeURIComponent('In @eLife: ');

--- a/src/components/atoms/title/title.tsx
+++ b/src/components/atoms/title/title.tsx
@@ -1,8 +1,7 @@
-import { JSX } from 'react';
 import { contentToJsx } from '../../../utils/content-to-jsx';
 import { Content } from '../../../types';
 import './title.scss';
 
-export const Title = ({ title }: { title: Content }): JSX.Element => (
+export const Title = ({ title }: { title: Content }) => (
   <h1 className="title">{contentToJsx(title)}</h1>
 );

--- a/src/components/layouts/default.tsx
+++ b/src/components/layouts/default.tsx
@@ -1,9 +1,9 @@
-import { JSX } from 'react';
+import { ReactNode } from 'react';
 import { SiteHeader } from '../molecules/site-header/site-header';
 import { SiteFooter } from '../molecules/site-footer/site-footer';
 import './default.scss';
 
-export const DefaultLayout = ({ children }: any): JSX.Element => (
+export const DefaultLayout = ({ children }: { children: ReactNode }) => (
   <>
     <div className="grid-container article-page">
       <div className="grid-header">

--- a/src/components/molecules/article-flag-list/article-flag-list.tsx
+++ b/src/components/molecules/article-flag-list/article-flag-list.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import { ArticleFlag } from '../../atoms/article-flag/article-flag';
 import './article-flag-list.scss';
 
@@ -34,7 +33,7 @@ const msaNames: Record<string, string> = {
 
 const msaURLs: Record<string, string> = Object.fromEntries(Object.entries(msaNames).map(([name, id]) => [name, `https://elifesciences.org/subjects/${id}`]));
 
-export const ArticleFlagList = ({ msas }: Props): JSX.Element => {
+export const ArticleFlagList = ({ msas }: Props) => {
   if (msas.length === 0) {
     return <></>;
   }

--- a/src/components/molecules/article-status/article-status.tsx
+++ b/src/components/molecules/article-status/article-status.tsx
@@ -1,4 +1,4 @@
-import { JSX, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '../../atoms/button/button';
 import { Clipboard } from '../../atoms/clipboard/clipboard';
 import { Socials } from '../../atoms/socials/socials';
@@ -28,7 +28,7 @@ const formatStringCitation = ({
 
 export const ArticleStatus = ({
   articleType = defaultArticleType, articleStatus, doi, title, pdfUrl, citation, msid,
-}: ArticleStatusProps): JSX.Element => {
+}: ArticleStatusProps) => {
   const [showShareModal, setShowShareModal] = useState(false);
   const [showCiteModal, setShowCiteModal] = useState(false);
 

--- a/src/components/molecules/author-information-list/author-information-list.tsx
+++ b/src/components/molecules/author-information-list/author-information-list.tsx
@@ -1,9 +1,9 @@
-import { Fragment, JSX } from 'react';
+import { Fragment } from 'react';
 import { Author } from '../../../types';
 import { createAuthorId } from '../../../utils/create-author-id';
 import './author-information-list.scss';
 
-const AuthorInformation = ({ author }: { author: Author }): JSX.Element => {
+const AuthorInformation = ({ author }: { author: Author }) => {
   const orcids = (author.identifiers ?? []).filter(({ type }) => type === 'orcid');
 
   return (
@@ -30,7 +30,7 @@ const AuthorInformation = ({ author }: { author: Author }): JSX.Element => {
   );
 };
 
-export const AuthorInformationList = ({ authors }: { authors: Author[] }): JSX.Element => (
+export const AuthorInformationList = ({ authors }: { authors: Author[] }) => (
   <section id="author-list" className="author-list">
     <h2 id="author-information" className="author-list__title">Author information</h2>
     <ol className="author-list__authors">

--- a/src/components/molecules/content-header/content-header.tsx
+++ b/src/components/molecules/content-header/content-header.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import './content-header.scss';
 import { Authors } from '../../atoms/authors/authors';
 import { Descriptors } from '../../atoms/descriptors/descriptors';
@@ -20,7 +19,7 @@ export const ContentHeader = ({
   title,
   authors,
   doi,
-}: ContentHeaderProps): JSX.Element => {
+}: ContentHeaderProps) => {
   const processedInstitutions = authors
     .flatMap((author) => author.affiliations)
     .filter(filterInstitutions)

--- a/src/components/molecules/contextual-data/contextual-data.tsx
+++ b/src/components/molecules/contextual-data/contextual-data.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import './contextual-data.scss';
 
 export type ContextualDataProps = {
@@ -7,7 +6,7 @@ export type ContextualDataProps = {
   tweets: number,
 };
 
-export const ContextualData = ({ views, citations, tweets }: ContextualDataProps): JSX.Element => (
+export const ContextualData = ({ views, citations, tweets }: ContextualDataProps) => (
   <ul className="contextual-data">
     <li className="contextual-data__item"><span className="contextual-data__item--highlight">{views}</span> {views === 1 ? 'view' : 'views'}</li>
     <li className="contextual-data__item"><span className="contextual-data__item--highlight">{citations}</span> {citations === 1 ? 'citation' : 'citations'}</li>

--- a/src/components/molecules/modal/modal.tsx
+++ b/src/components/molecules/modal/modal.tsx
@@ -1,5 +1,5 @@
 import {
-  JSX, useRef, MouseEvent,
+  useRef, MouseEvent,
 } from 'react';
 import './modal.scss';
 
@@ -17,7 +17,7 @@ export const Modal = ({
   open = false,
   onModalClose,
   modalLayout,
-}: Props): JSX.Element => {
+}: Props) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
   const clickDetectedOutsideOfModal = (event: MouseEvent<HTMLDivElement>) => contentRef.current && !contentRef.current.contains(event.target as Element);

--- a/src/components/molecules/site-footer/site-footer.tsx
+++ b/src/components/molecules/site-footer/site-footer.tsx
@@ -1,8 +1,7 @@
-import { JSX } from 'react';
 import { FooterMain } from '../../atoms/footer-main/footer-main';
 import { Investors } from '../../atoms/investors/investors';
 import { SignUp } from '../../atoms/sign-up/sign-up';
 
-export const SiteFooter = (): JSX.Element => (
+export const SiteFooter = () => (
   <><SignUp /><Investors /><FooterMain /></>
 );

--- a/src/components/molecules/site-header/site-header.tsx
+++ b/src/components/molecules/site-header/site-header.tsx
@@ -1,12 +1,12 @@
 import Image from 'next/image';
-import { JSX, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import './site-header.scss';
 import logo from '../../../../public/elife-logo.svg';
 
-const Overlay = ({ closeOverlay }: { closeOverlay: () => void }): JSX.Element => createPortal(<div onClick={() => closeOverlay()} className="overlay" id="overlayMainMenu"></div>, document.getElementsByTagName('BODY')[0]);
+const Overlay = ({ closeOverlay }: { closeOverlay: () => void }) => createPortal(<div onClick={() => closeOverlay()} className="overlay" id="overlayMainMenu"></div>, document.getElementsByTagName('BODY')[0]);
 
-export const SiteHeader = (): JSX.Element => {
+export const SiteHeader = () => {
   const [showMenu, setShowMenu] = useState(false);
   return (
     <div className="site-header">

--- a/src/components/molecules/timeline/timeline.tsx
+++ b/src/components/molecules/timeline/timeline.tsx
@@ -1,4 +1,4 @@
-import { Fragment, JSX } from 'react';
+import { Fragment } from 'react';
 import './timeline.scss';
 
 type TimelineEventBasic = {
@@ -33,7 +33,7 @@ type TimelineProps = {
 
 const formatDate = (date: string): string => new Date(date).toLocaleString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
-export const Timeline = ({ events, listDescription }: TimelineProps): JSX.Element => (
+export const Timeline = ({ events, listDescription }: TimelineProps) => (
   <div className="review-timeline">
     <dl className="review-timeline__list" aria-label={listDescription}>
       {

--- a/src/components/pages/article/article-page.tsx
+++ b/src/components/pages/article/article-page.tsx
@@ -1,4 +1,4 @@
-import { JSX, ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { ArticleStatus } from '../../molecules/article-status/article-status';
 import { ContentHeader } from '../../molecules/content-header/content-header';
 import { Timeline, TimelineEvent } from '../../molecules/timeline/timeline';
@@ -30,7 +30,7 @@ export type ArticlePageProps = {
   tabs: Tab[],
 };
 
-export const ArticlePage = (props: ArticlePageProps): JSX.Element => {
+export const ArticlePage = (props: ArticlePageProps) => {
   const doi = getRppVersionDoi(props.metaData);
 
   const citation: CitationData = {

--- a/src/components/pages/article/tabs/figures-tab.tsx
+++ b/src/components/pages/article/tabs/figures-tab.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import '../article-page.scss';
 import { Heading } from '../../../atoms/heading/heading';
 import { ArticleContent } from '../../../atoms/article-content/article-content';
@@ -23,7 +22,7 @@ const getFigures = (content: Content): Content => {
   }
 };
 
-export const ArticleFiguresTab = ({ content }: { content: Content }): JSX.Element => (
+export const ArticleFiguresTab = ({ content }: { content: Content }) => (
   <div className="tabbed-navigation__content">
     <div className="menu-spacer"/>
     <div className="article-body-container">

--- a/src/components/pages/article/tabs/fulltext-tab.tsx
+++ b/src/components/pages/article/tabs/fulltext-tab.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import '../article-page.scss';
 import { ArticleContent } from '../../../atoms/article-content/article-content';
 import { JumpToMenu } from '../../../atoms/jump-to-menu/jump-to-menu';
@@ -9,7 +8,7 @@ import { AuthorInformationList } from '../../../molecules/author-information-lis
 import { Content, MetaData, PeerReview } from '../../../../types';
 import { contentToHeadings } from '../../../../utils/content-to-headings';
 
-export const ArticleFullTextTab = (props: { metaData: MetaData, content: Content, peerReview?: PeerReview, peerReviewUrl?: string, }): JSX.Element => {
+export const ArticleFullTextTab = (props: { metaData: MetaData, content: Content, peerReview?: PeerReview, peerReviewUrl?: string, }) => {
   const headings = [
     { id: 'abstract', text: 'Abstract' },
     ...contentToHeadings(props.content),

--- a/src/components/pages/article/tabs/reviews-tab.tsx
+++ b/src/components/pages/article/tabs/reviews-tab.tsx
@@ -1,11 +1,10 @@
-import { JSX } from 'react';
 import '../article-page.scss';
 import { EditorsAndReviewers } from '../../../atoms/editors-and-reviewers/editors-and-reviewers';
 import { ReviewContent } from '../../../atoms/review-content/review-content';
 import { PeerReview } from '../../../../types';
 import { JumpToMenu } from '../../../atoms/jump-to-menu/jump-to-menu';
 
-export const ArticleReviewsTab = ({ peerReview }: { peerReview: PeerReview }): JSX.Element => {
+export const ArticleReviewsTab = ({ peerReview }: { peerReview: PeerReview }) => {
   const headings = [
     { id: 'editors-and-reviewers', text: 'Editors' },
     ...peerReview.reviews.map((_, index) => (

--- a/src/components/pages/error-pages/page-not-found.tsx
+++ b/src/components/pages/error-pages/page-not-found.tsx
@@ -1,10 +1,9 @@
 import Image from 'next/image';
-import { JSX } from 'react';
 import './page-not-found.scss';
 import MissingImage from '../../../images/errors/404.svg';
 import { Button } from '../../atoms/button/button';
 
-export const PageNotFound = (): JSX.Element => (
+export const PageNotFound = () => (
   <main className="full-width-section">
     <div className="error-wrapper">
       <div className="error">

--- a/src/pages/404.page.tsx
+++ b/src/pages/404.page.tsx
@@ -1,6 +1,5 @@
-import { JSX } from 'react';
 import { PageNotFound } from '../components/pages/error-pages/page-not-found';
 
-export const MissingPage = (): JSX.Element => <PageNotFound />;
+export const MissingPage = () => <PageNotFound />;
 
 export default MissingPage;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,5 +1,4 @@
 import { GetServerSideProps } from 'next';
-import { JSX } from 'react';
 import Link from 'next/link';
 import { config } from '../config';
 import { getManuscripts } from '../manuscripts';
@@ -8,7 +7,7 @@ import { fetchVersions } from '../utils/fetch-data';
 type PageProps = {
   ids: string[]
 };
-export const App = ({ ids }: PageProps): JSX.Element => (
+export const App = ({ ids }: PageProps) => (
   <div className="App">
     <ul>
       {ids

--- a/src/pages/preview/[...path].page.tsx
+++ b/src/pages/preview/[...path].page.tsx
@@ -1,4 +1,3 @@
-import { JSX } from 'react';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -16,7 +15,7 @@ type PageProps = {
   content: Content,
 };
 
-export const Page = (props: PageProps): JSX.Element => {
+export const Page = (props: PageProps) => {
   const router = useRouter();
   const determineTab = () => {
     if (Array.isArray(router.query.path)) {

--- a/src/pages/reviewed-preprints/[...path].page.tsx
+++ b/src/pages/reviewed-preprints/[...path].page.tsx
@@ -34,7 +34,7 @@ const getPublishedDate = (events: TimelineEvent[]): string | undefined => {
   return undefined;
 };
 
-export const Page = (props: PageProps): JSX.Element => {
+export const Page = (props: PageProps) => {
   const routePrefix = props.status.isPreview ? '/previews/' : '/reviewed-preprints/';
   const tabLinks = [
     {


### PR DESCRIPTION
The currently considered best practice is to not type the output of the jsx components and to leave it to be inferred. 

This means we wont need to return empty jsx tags like `<></>` and can return undefined which will be ignored when rendering.

see here: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components