### PR TITLE
feat: Allow string input for volumeNumber in Publication type

### DIFF
--- a/src/types/reference.ts
+++ b/src/types/reference.ts
@@ -5,7 +5,7 @@ type PublicationType = 'PublicationVolume' | 'Periodical';
 type Publication = {
   type: PublicationType,
   name?: string,
-  volumeNumber?: number,
+  volumeNumber?: number | string,
   issueNumber?: number,
   isPartOf?: Publication,
 };

--- a/src/utils/mocks/references.ts
+++ b/src/utils/mocks/references.ts
@@ -51,7 +51,7 @@ export const references: Reference[] = [
       { type: 'Person', familyNames: ['Eghbali'], givenNames: ['M'] },
     ],
     datePublished: '2020-01-01T00:00:00.000Z',
-    isPartOf: { type: 'Periodical', name: 'Int J Mol Sci' },
+    isPartOf: { type: 'Periodical', name: 'Int J Mol Sci', volumeNumber: 'volume one' },
     pageStart: 21,
     title: 'The Role of Estrogen Receptors in Cardiovascular Disease',
     identifiers: [


### PR DESCRIPTION
This commit modifies the structure of the Publication type to accept a string or number for volumeNumber, and updates the mock references accordingly.