### PR TITLE
feat: make prepareAuthor function exportable and use it in [msid].page.ts

### DIFF
--- a/browser-tests/api-reviewed-preprints.spec.ts
+++ b/browser-tests/api-reviewed-preprints.spec.ts
@@ -36,7 +36,7 @@ test('reviewed preprints api item found', async ({ request }) => {
   expect(responseJson.doi).toBe('10.1101/123456');
   expect(responseJson.title).toBe('Tonight we take over the world!');
   expect(responseJson.indexContent).toContain('On the subject of sidekicks');
-  expect(responseJson.indexContent).toContain('Brain Pinky MouseSlowpoke RodreigezSylvester J PussycatElmer FuddYosemite SamFogghorn LeghornPepe Le PewPorky PigSpeedy GonzalesBugs Bunny');
+  expect(responseJson.indexContent).toContain('Brain, Pinky Mouse, Slowpoke Rodreigez, Sylvester J Pussycat, Elmer Fudd, Yosemite Sam, Fogghorn Leghorn, Pepe Le Pew, Porky Pig, Speedy Gonzales, Bugs Bunny');
 });
 
 test('reviewed preprints api item unknown', async ({ request }) => {

--- a/browser-tests/api-reviewed-preprints.spec.ts
+++ b/browser-tests/api-reviewed-preprints.spec.ts
@@ -36,6 +36,7 @@ test('reviewed preprints api item found', async ({ request }) => {
   expect(responseJson.doi).toBe('10.1101/123456');
   expect(responseJson.title).toBe('Tonight we take over the world!');
   expect(responseJson.indexContent).toContain('On the subject of sidekicks');
+  expect(responseJson.indexContent).toContain('Brain Pinky MouseSlowpoke RodreigezSylvester J PussycatElmer FuddYosemite SamFogghorn LeghornPepe Le PewPorky PigSpeedy GonzalesBugs Bunny');
 });
 
 test('reviewed preprints api item unknown', async ({ request }) => {

--- a/src/pages/api/reviewed-preprints.page.test.ts
+++ b/src/pages/api/reviewed-preprints.page.test.ts
@@ -65,6 +65,12 @@ describe('reviewedPreprintSnippet', () => {
             'Author 4',
           ],
         },
+        {
+          givenNames: [
+            'No family names',
+          ],
+          familyNames: [],
+        },
       ],
       doi: 'preprintprovider/preprint1',
       msas: [],

--- a/src/pages/api/reviewed-preprints.page.test.ts
+++ b/src/pages/api/reviewed-preprints.page.test.ts
@@ -87,7 +87,7 @@ describe('reviewedPreprintSnippet', () => {
       doi: 'preprintprovider/preprint1',
       pdf: 'https://www.preprintprovider.org/content/preprint1.pdf',
       status: 'reviewed',
-      authorLine: 'First Middle Last Author 1, First Middle Last Author 2 ... First Middle Last Author 4',
+      authorLine: 'First Middle Last Author 1, First Middle Last Author 2 ... No family names',
       title: 'title',
       published: '2022-10-20T03:00:00Z',
       reviewedDate: '2022-10-20T03:00:00Z',

--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -36,7 +36,12 @@ type ReviewedPreprintListResponse = {
   items: ReviewedPreprintSnippet[],
 };
 
-export const prepareAuthor = (author: Author) : string => `${(author.givenNames ?? []).join(' ')} ${(author.familyNames ?? []).join(' ')}`;
+export const prepareAuthor = (author: Author) : string => {
+  const givenNames = (author.givenNames ?? []).join(' ');
+  const familyNames = (author.familyNames ?? []).join(' ');
+
+  return `${givenNames}${familyNames ? ' ' : ''}${familyNames}`;
+};
 
 const prepareAuthorLine = (authors: Author[]) : undefined | string => {
   if (authors.length === 0) {

--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -36,7 +36,7 @@ type ReviewedPreprintListResponse = {
   items: ReviewedPreprintSnippet[],
 };
 
-const prepareAuthor = (author: Author) : string => `${(author.givenNames ?? []).join(' ')} ${(author.familyNames ?? []).join(' ')}`;
+export const prepareAuthor = (author: Author) : string => `${(author.givenNames ?? []).join(' ')} ${(author.familyNames ?? []).join(' ')}`;
 
 const prepareAuthorLine = (authors: Author[]) : undefined | string => {
   if (authors.length === 0) {

--- a/src/pages/api/reviewed-preprints/[msid].page.ts
+++ b/src/pages/api/reviewed-preprints/[msid].page.ts
@@ -25,7 +25,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       res,
       'application/vnd.elife.reviewed-preprint-item+json; version=1',
       200,
-      { ...reviewedPreprintSnippet(manuscript, metaData), indexContent: `${metaData.authors.map((author) => prepareAuthor(author)).join('')} ${contentToHtml(content)}` },
+      { ...reviewedPreprintSnippet(manuscript, metaData), indexContent: `${metaData.authors.map((author) => prepareAuthor(author)).join(', ')} ${contentToHtml(content)}` },
     );
   } else {
     console.log('Cannot find msid configured'); // eslint-disable-line no-console

--- a/src/pages/api/reviewed-preprints/[msid].page.ts
+++ b/src/pages/api/reviewed-preprints/[msid].page.ts
@@ -3,7 +3,12 @@ import { config } from '../../../config';
 import { getManuscript } from '../../../manuscripts';
 import { contentToHtml } from '../../../utils/content-to-html';
 import { fetchContent, fetchMetadata } from '../../../utils/fetch-data';
-import { errorNotFoundRequest, reviewedPreprintSnippet, writeResponse } from '../reviewed-preprints.page';
+import {
+  errorNotFoundRequest,
+  prepareAuthor,
+  reviewedPreprintSnippet,
+  writeResponse,
+} from '../reviewed-preprints.page';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { msid } = req.query;
@@ -20,7 +25,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       res,
       'application/vnd.elife.reviewed-preprint-item+json; version=1',
       200,
-      { ...reviewedPreprintSnippet(manuscript, metaData), indexContent: contentToHtml(content) },
+      { ...reviewedPreprintSnippet(manuscript, metaData), indexContent: `${metaData.authors.map((author) => prepareAuthor(author)).join('')} ${contentToHtml(content)}` },
     );
   } else {
     console.log('Cannot find msid configured'); // eslint-disable-line no-console


### PR DESCRIPTION
The `prepareAuthor` function from `reviewed-preprints.page.ts` is now exportable. It is imported and utilized in `reviewed-preprints/[msid].page.ts` to prepare the authors' metadata.