### PR TITLE
feat: update fetchVersionsNoContent and reviewed-preprints.page

### DIFF
--- a/src/utils/fetch-data.ts
+++ b/src/utils/fetch-data.ts
@@ -28,4 +28,4 @@ export const fetchReviews = (id: string) => {
 
 export const fetchVersion = (id: string, preview: boolean = false) => jsonFetchOrNull<EnhancedArticleWithVersions>(`${config.apiServer}/api/preprints/${id}${preview ? '?previews=true' : ''}`);
 export const fetchVersions = () => jsonFetch<{ items: ArticleSummary[], total: number }>(`${config.apiServer}/api/preprints`);
-export const fetchVersionsNoContent = () => jsonFetch<EnhancedArticleNoContent[]>(`${config.apiServer}/api/preprints-no-content`);
+export const fetchVersionsNoContent = (page: number, perPage: number, order: string) => jsonFetch<EnhancedArticleNoContent[]>(`${config.apiServer}/api/preprints-no-content?page=${page}&per-page=${perPage}&order=${order}`);


### PR DESCRIPTION
Update fetchVersionsNoContent to take parameters for pagination and ordering. Remove redundant logic from reviewed-preprints.page.ts and replace with fetchVersionsNoContent function.