### PR TITLE
feat: update 'published' and 'reviewedDate' to use 'firstPublished'

### DIFF
--- a/src/pages/api/reviewed-preprints.page.test.ts
+++ b/src/pages/api/reviewed-preprints.page.test.ts
@@ -1,5 +1,5 @@
 import { reviewedPreprintSnippet } from './reviewed-preprints.page';
-import { Author } from '../../types/author';
+import { Author } from '../../types';
 
 describe('reviewedPreprintSnippet', () => {
   it('prepares a reviewed preprint snippet with manuscript and metadata', () => {

--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -134,15 +134,15 @@ export const enhancedArticleToReviewedPreprintItemResponse = ({
   published,
   subjects,
   article: { content, authors },
-}: EnhancedArticle): ReviewedPreprintItemResponse => ({
+}: EnhancedArticle, firstPublished: Date | null): ReviewedPreprintItemResponse => ({
   id: msid,
   doi: preprintDoi,
   pdf: pdfUrl,
   status: 'reviewed',
   authorLine: prepareAuthorLine(authors || []),
   title: contentToHtml(article.title),
-  published: new Date(published!).toISOString(),
-  reviewedDate: new Date(published!).toISOString(),
+  published: new Date(firstPublished ?? published!).toISOString(),
+  reviewedDate: new Date(firstPublished ?? published!).toISOString(),
   versionDate: new Date(published!).toISOString(),
   statusDate: new Date(published!).toISOString(),
   stage: 'published',

--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -110,6 +110,7 @@ export const enhancedArticleNoContentToSnippet = ({
   article,
   published,
   subjects,
+  firstPublished,
 }: EnhancedArticleNoContent): ReviewedPreprintSnippet => ({
   id: msid,
   doi: preprintDoi,
@@ -117,8 +118,8 @@ export const enhancedArticleNoContentToSnippet = ({
   status: 'reviewed',
   authorLine: prepareAuthorLine(article.authors || []),
   title: contentToHtml(article.title),
-  published: new Date(published!).toISOString(),
-  reviewedDate: new Date(published!).toISOString(),
+  published: new Date(firstPublished).toISOString(),
+  reviewedDate: new Date(firstPublished).toISOString(),
   versionDate: new Date(published!).toISOString(),
   statusDate: new Date(published!).toISOString(),
   stage: 'published',

--- a/src/pages/api/reviewed-preprints/[msid].page.ts
+++ b/src/pages/api/reviewed-preprints/[msid].page.ts
@@ -10,6 +10,7 @@ import {
   writeResponse,
   enhancedArticleToReviewedPreprintItemResponse,
 } from '../reviewed-preprints.page';
+import { VersionSummary } from '../../../types';
 
 const serverApi = async (req: NextApiRequest, res: NextApiResponse) => {
   const msid = (Array.isArray(req.query.msid) ? req.query.msid[0] : req.query.msid) ?? '';
@@ -19,6 +20,8 @@ const serverApi = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const version = await fetchVersion(msid);
+  const firstPublished = Object.values(version?.versions || {} as VersionSummary[])
+    .reduce((min: null | VersionSummary, v) => ((!min || (min.published && v.published && v.published < min.published)) ? v : min), null);
   if (!version || version === null) {
     errorNotFoundRequest(res);
     return;
@@ -28,7 +31,7 @@ const serverApi = async (req: NextApiRequest, res: NextApiResponse) => {
     res,
     'application/vnd.elife.reviewed-preprint+json; version=1',
     200,
-    enhancedArticleToReviewedPreprintItemResponse(version.article),
+    enhancedArticleToReviewedPreprintItemResponse(version.article, firstPublished?.published ?? null),
   );
 };
 

--- a/src/types/reviewed-preprint-snippet.ts
+++ b/src/types/reviewed-preprint-snippet.ts
@@ -22,4 +22,5 @@ export type VersionSummary = Omit<EnhancedArticle, 'article' | 'peerReview'>;
 
 export type EnhancedArticleNoContent = VersionSummary & {
   article: Omit<ProcessedArticle, 'doi' | 'date' | 'content' | 'abstract'>,
+  firstPublished: Date,
 };


### PR DESCRIPTION
This commit updates the 'published' and 'reviewedDate' properties in the 'reviewedPreprintSnippet' function to use 'firstPublished' instead of 'published'. Also, it adds 'firstPublished' as a new property in the 'EnhancedArticleNoContent' type. Additionally, it changes the import path of 'Author' in the 'reviewed-preprints.page.test.ts' file.