### PR TITLE
Rewrite journal API to use summary and full content APIs

### DIFF
--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -9,7 +9,6 @@ import {
 import { getSubjects } from '../../components/molecules/article-flag-list/article-flag-list';
 import { TimelineEvent } from '../../components/molecules/timeline/timeline';
 import { contentToHtml } from '../../utils/content-to-html';
-import { EnhancedArticleNoContent } from '../../types/reviewed-preprint-snippet';
 
 type BadRequestMessage = {
   title: 'bad request' | 'not found',

--- a/src/pages/api/reviewed-preprints.page.ts
+++ b/src/pages/api/reviewed-preprints.page.ts
@@ -104,28 +104,6 @@ export const reviewedPreprintSnippet = (manuscript: FullManuscriptConfig, meta?:
   };
 };
 
-export const enhancedArticleNoContentToSnippet = ({
-  msid,
-  preprintDoi,
-  pdfUrl,
-  article,
-  published,
-  subjects,
-}: EnhancedArticleNoContent): ReviewedPreprintSnippet => ({
-  id: msid,
-  doi: preprintDoi,
-  pdf: pdfUrl,
-  status: 'reviewed',
-  authorLine: prepareAuthorLine(article.authors || []),
-  title: contentToHtml(article.title),
-  published: new Date(published!).toISOString(),
-  reviewedDate: new Date(published!).toISOString(),
-  versionDate: new Date(published!).toISOString(),
-  statusDate: new Date(published!).toISOString(),
-  stage: 'published',
-  subjects: getSubjects(subjects || []),
-});
-
 export const articleSummaryToSnippet = async (summary: ArticleSummaryWithFirstPublished): Promise<ReviewedPreprintSnippet | null> => {
   const version = (await fetchVersion(summary.id));
 

--- a/src/types/enhanced-article.ts
+++ b/src/types/enhanced-article.ts
@@ -70,6 +70,7 @@ export type ProcessedArticle = {
 export type ArticleSummary = {
   id: string,
   doi: string,
+  msid?: string,
   title: ArticleTitle,
   date: Date | null,
 };


### PR DESCRIPTION
This restores an alternative path whereby we utilise the server summary api to generate a list, then slice the list, then fetch further content from the full content API.

Possibly, we could optimise further by creating a nocontentbyid API, to not pull down the full content for the journal api index