### PR TITLE
Figure img alt text

### DIFF
--- a/src/components/atoms/figure/figure.stories.tsx
+++ b/src/components/atoms/figure/figure.stories.tsx
@@ -53,6 +53,21 @@ Figure2.args = {
   }),
 };
 
+export const NotAccessibleFigure = Template.bind({});
+NotAccessibleFigure.args = {
+  label: 'Figure 1',
+  caption: 'This is a figure',
+  id: '1',
+  content: contentToJsx({
+    type: 'ImageObject',
+    meta: {
+      inline: false,
+    },
+    contentUrl: 'https://placekitten.com/800/400',
+  }),
+  labelAriaHidden: false,
+  captionAriaHidden: false,
+};
 export const AccessibleFigure = Template.bind({});
 AccessibleFigure.args = {
   label: 'Figure 1',

--- a/src/components/atoms/figure/figure.stories.tsx
+++ b/src/components/atoms/figure/figure.stories.tsx
@@ -14,47 +14,74 @@ const Template: StoryFn<typeof Figure> = (args) => (
 export const Figure1 = Template.bind({});
 Figure1.args = {
   content: contentToJsx({
-    type: 'Figure',
-    content: {
-      type: 'ImageObject',
-      meta: {
-        inline: false,
-      },
-      contentUrl: 'https://placekitten.com/800/400',
+    type: 'ImageObject',
+    meta: {
+      inline: false,
     },
+    contentUrl: 'https://placekitten.com/800/400',
   }),
 };
 
 export const Figure2 = Template.bind({});
 Figure2.args = {
-  content: contentToJsx({
-    type: 'Figure',
-    label: 'This is a figure Component',
-    caption: [
-      {
-        type: 'Heading',
-        content: 'This is a figure',
-        depth: 3,
-        id: 'fig1',
-      },
-      {
-        type: 'Paragraph',
-        // eslint-disable-next-line max-len
-        content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quis fringilla nunc. Pellentesque nec vestibulum sapien, eu feugiat turpis. Maecenas scelerisque at dolor sed venenatis. Nunc tempus, est eu ultricies placerat, magna dui facilisis turpis, et suscipit nunc elit at massa. Mauris sed lectus vulputate lacus aliquet dapibus. Proin accumsan, ligula non maximus molestie, mi tortor facilisis velit, sed hendrerit tortor sapien et purus. Duis ullamcorper nulla sed ante vehicula suscipit et aliquet ligula. Maecenas sollicitudin, odio ut ultricies commodo, nibh massa consectetur nibh, sit amet accumsan magna sapien at tortor. Nunc tempus, erat ut vestibulum molestie, lacus mi mattis ligula, et dignissim erat ex sit amet massa. In vel ornare sapien. Praesent porttitor neque et feugiat ultrices. Nullam sit amet lorem ac nisl dapibus ultrices sit amet eu ex.',
-      },
-      {
-        type: 'Paragraph',
-        // eslint-disable-next-line max-len
-        content: 'Fusce urna metus, hendrerit in turpis non, hendrerit convallis neque. Curabitur ut mi vel dui convallis rhoncus vitae at est. Nulla facilisi. Nulla fringilla sem nisi, in ullamcorper ex congue sed. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ac faucibus ex. Aliquam egestas ante a volutpat dapibus. Nunc non vulputate magna. Vestibulum eget neque nec nibh porta ultricies. Vivamus dictum at libero nec condimentum. Ut ac nunc nec tellus vehicula pharetra. Sed vitae molestie diam.',
-      },
-    ],
-    id: '1',
-    content: {
-      type: 'ImageObject',
-      meta: {
-        inline: false,
-      },
-      contentUrl: 'https://placekitten.com/800/400',
+  label: 'This is a figure Component',
+  caption: contentToJsx([
+    {
+      type: 'Heading',
+      content: 'This is a figure',
+      depth: 3,
+      id: 'fig1',
     },
+    {
+      type: 'Paragraph',
+      // eslint-disable-next-line max-len
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quis fringilla nunc. Pellentesque nec vestibulum sapien, eu feugiat turpis. Maecenas scelerisque at dolor sed venenatis. Nunc tempus, est eu ultricies placerat, magna dui facilisis turpis, et suscipit nunc elit at massa. Mauris sed lectus vulputate lacus aliquet dapibus. Proin accumsan, ligula non maximus molestie, mi tortor facilisis velit, sed hendrerit tortor sapien et purus. Duis ullamcorper nulla sed ante vehicula suscipit et aliquet ligula. Maecenas sollicitudin, odio ut ultricies commodo, nibh massa consectetur nibh, sit amet accumsan magna sapien at tortor. Nunc tempus, erat ut vestibulum molestie, lacus mi mattis ligula, et dignissim erat ex sit amet massa. In vel ornare sapien. Praesent porttitor neque et feugiat ultrices. Nullam sit amet lorem ac nisl dapibus ultrices sit amet eu ex.',
+    },
+    {
+      type: 'Paragraph',
+      // eslint-disable-next-line max-len
+      content: 'Fusce urna metus, hendrerit in turpis non, hendrerit convallis neque. Curabitur ut mi vel dui convallis rhoncus vitae at est. Nulla facilisi. Nulla fringilla sem nisi, in ullamcorper ex congue sed. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ac faucibus ex. Aliquam egestas ante a volutpat dapibus. Nunc non vulputate magna. Vestibulum eget neque nec nibh porta ultricies. Vivamus dictum at libero nec condimentum. Ut ac nunc nec tellus vehicula pharetra. Sed vitae molestie diam.',
+    },
+  ]),
+  id: '1',
+  content: contentToJsx({
+    type: 'ImageObject',
+    meta: {
+      inline: false,
+    },
+    contentUrl: 'https://placekitten.com/800/400',
   }),
+};
+
+export const Figure3 = Template.bind({});
+Figure3.args = {
+  label: 'This is a figure Component with aria-hidden',
+  caption: contentToJsx([
+    {
+      type: 'Heading',
+      content: 'This is a figure',
+      depth: 3,
+      id: 'fig1',
+    },
+    {
+      type: 'Paragraph',
+      // eslint-disable-next-line max-len
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quis fringilla nunc. Pellentesque nec vestibulum sapien, eu feugiat turpis. Maecenas scelerisque at dolor sed venenatis. Nunc tempus, est eu ultricies placerat, magna dui facilisis turpis, et suscipit nunc elit at massa. Mauris sed lectus vulputate lacus aliquet dapibus. Proin accumsan, ligula non maximus molestie, mi tortor facilisis velit, sed hendrerit tortor sapien et purus. Duis ullamcorper nulla sed ante vehicula suscipit et aliquet ligula. Maecenas sollicitudin, odio ut ultricies commodo, nibh massa consectetur nibh, sit amet accumsan magna sapien at tortor. Nunc tempus, erat ut vestibulum molestie, lacus mi mattis ligula, et dignissim erat ex sit amet massa. In vel ornare sapien. Praesent porttitor neque et feugiat ultrices. Nullam sit amet lorem ac nisl dapibus ultrices sit amet eu ex.',
+    },
+    {
+      type: 'Paragraph',
+      // eslint-disable-next-line max-len
+      content: 'Fusce urna metus, hendrerit in turpis non, hendrerit convallis neque. Curabitur ut mi vel dui convallis rhoncus vitae at est. Nulla facilisi. Nulla fringilla sem nisi, in ullamcorper ex congue sed. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ac faucibus ex. Aliquam egestas ante a volutpat dapibus. Nunc non vulputate magna. Vestibulum eget neque nec nibh porta ultricies. Vivamus dictum at libero nec condimentum. Ut ac nunc nec tellus vehicula pharetra. Sed vitae molestie diam.',
+    },
+  ]),
+  id: '1',
+  content: contentToJsx({
+    type: 'ImageObject',
+    meta: {
+      inline: false,
+    },
+    contentUrl: 'https://placekitten.com/800/400',
+  }),
+  labelAriaHidden: true,
+  captionAriaHidden: true,
 };

--- a/src/components/atoms/figure/figure.stories.tsx
+++ b/src/components/atoms/figure/figure.stories.tsx
@@ -53,27 +53,10 @@ Figure2.args = {
   }),
 };
 
-export const Figure3 = Template.bind({});
-Figure3.args = {
-  label: 'This is a figure Component with aria-hidden',
-  caption: contentToJsx([
-    {
-      type: 'Heading',
-      content: 'This is a figure',
-      depth: 3,
-      id: 'fig1',
-    },
-    {
-      type: 'Paragraph',
-      // eslint-disable-next-line max-len
-      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec quis fringilla nunc. Pellentesque nec vestibulum sapien, eu feugiat turpis. Maecenas scelerisque at dolor sed venenatis. Nunc tempus, est eu ultricies placerat, magna dui facilisis turpis, et suscipit nunc elit at massa. Mauris sed lectus vulputate lacus aliquet dapibus. Proin accumsan, ligula non maximus molestie, mi tortor facilisis velit, sed hendrerit tortor sapien et purus. Duis ullamcorper nulla sed ante vehicula suscipit et aliquet ligula. Maecenas sollicitudin, odio ut ultricies commodo, nibh massa consectetur nibh, sit amet accumsan magna sapien at tortor. Nunc tempus, erat ut vestibulum molestie, lacus mi mattis ligula, et dignissim erat ex sit amet massa. In vel ornare sapien. Praesent porttitor neque et feugiat ultrices. Nullam sit amet lorem ac nisl dapibus ultrices sit amet eu ex.',
-    },
-    {
-      type: 'Paragraph',
-      // eslint-disable-next-line max-len
-      content: 'Fusce urna metus, hendrerit in turpis non, hendrerit convallis neque. Curabitur ut mi vel dui convallis rhoncus vitae at est. Nulla facilisi. Nulla fringilla sem nisi, in ullamcorper ex congue sed. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec ac faucibus ex. Aliquam egestas ante a volutpat dapibus. Nunc non vulputate magna. Vestibulum eget neque nec nibh porta ultricies. Vivamus dictum at libero nec condimentum. Ut ac nunc nec tellus vehicula pharetra. Sed vitae molestie diam.',
-    },
-  ]),
+export const AccessibleFigure = Template.bind({});
+AccessibleFigure.args = {
+  label: 'Figure 1',
+  caption: 'This is a figure',
   id: '1',
   content: contentToJsx({
     type: 'ImageObject',
@@ -81,7 +64,7 @@ Figure3.args = {
       inline: false,
     },
     contentUrl: 'https://placekitten.com/800/400',
-  }),
-  labelAriaHidden: true,
+  }, { altText: 'This is a figure' }),
+  labelAriaHidden: false,
   captionAriaHidden: true,
 };

--- a/src/components/atoms/figure/figure.test.tsx
+++ b/src/components/atoms/figure/figure.test.tsx
@@ -23,10 +23,24 @@ describe('Figure', () => {
     expect(screen.getByText('I am a label')).toBeInTheDocument();
   });
 
+  it('renders the label with aria-hidden label', () => {
+    render(<Figure content={contentToJsx(content.content)} label={content.label} labelAriaHidden={true}/>);
+
+    expect(screen.getByText('I am a label')).toBeInTheDocument();
+    expect(screen.getByText('I am a label').getAttribute('aria-hidden')).toEqual('true');
+  });
+
   it('renders the caption', () => {
     render(<Figure content={contentToJsx(content.content)} caption={content.caption}/>);
 
     expect(screen.getByText('this is a figure')).toBeInTheDocument();
+  });
+
+  it('renders the caption with aria-hidden label', () => {
+    render(<Figure content={contentToJsx(content.content)} caption={content.caption} captionAriaHidden={true}/>);
+
+    expect(screen.getByText('this is a figure')).toBeInTheDocument();
+    expect(screen.getByText('this is a figure').getAttribute('aria-hidden')).toEqual('true');
   });
 
   it('should not render caption, label, or ID if not defined', () => {

--- a/src/components/atoms/figure/figure.tsx
+++ b/src/components/atoms/figure/figure.tsx
@@ -1,9 +1,18 @@
 import { useRef, useState, useEffect } from 'react';
 import './figure.scss';
 
+type Props = {
+  content: React.ReactNode,
+  id?: string,
+  caption?: React.ReactNode,
+  label?: string,
+  captionAriaHidden?: boolean,
+  labelAriaHidden?: boolean,
+};
+
 export const Figure = ({
-  id, content, caption, label,
-}: { content: React.ReactNode, id?: string, caption?: React.ReactNode, label?: string }) => {
+  id, content, caption, label, captionAriaHidden, labelAriaHidden,
+}: Props) => {
   const captionRef = useRef<HTMLElement>(null);
   const [expanded, setExpanded] = useState(false);
   const [showButton, setShowButton] = useState(false);
@@ -35,9 +44,9 @@ export const Figure = ({
   return (
     <div className="figure-container">
       <figure className="figure" {...(id && { id })}>
-        {label && <label className="figure__label">{label}</label>}
+        {label && <label {...(labelAriaHidden ? { 'aria-hidden': 'true' } : {})} className="figure__label">{label}</label>}
         {content}
-        {caption && <figcaption ref={captionRef} className={`figure__caption${expanded ? ' figure__caption--expanded' : ''}`}>{caption}</figcaption>}
+        {caption && <figcaption {...(captionAriaHidden ? { 'aria-hidden': 'true' } : {})} ref={captionRef} className={`figure__caption${expanded ? ' figure__caption--expanded' : ''}`}>{caption}</figcaption>}
       </figure>
       {showButton && (<button className={`figure__caption__button${expanded ? ' expanded' : ''}`} onClick={() => { setExpanded(!expanded); }}>{expanded ? 'Show less' : 'Show more'}</button>)}
     </div>

--- a/src/utils/content-to-jsx.test.tsx
+++ b/src/utils/content-to-jsx.test.tsx
@@ -125,6 +125,68 @@ describe('Content to JSX', () => {
     );
   });
 
+  it('generates the expected alt when passed a Figure with a caption and an image', () => {
+    render(<>
+      {contentToJsx({
+        type: 'Figure',
+        content: {
+          type: 'ImageObject',
+          contentUrl: 'https://placekitten.com/500/300',
+          content: [],
+          meta: {
+            inline: false,
+          },
+        },
+        caption: 'I am a caption',
+      })}
+    </>);
+
+    const imgElement = document.querySelector('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a caption');
+  });
+
+  it('generates the expected alt when passed a Figure with a label and an image', () => {
+    render(<>
+      {contentToJsx({
+        type: 'Figure',
+        label: 'I am a label',
+        content: {
+          type: 'ImageObject',
+          contentUrl: 'https://placekitten.com/500/300',
+          meta: {
+            inline: false,
+          },
+        },
+      })}
+    </>);
+
+    const imgElement = document.querySelector('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a label');
+  });
+
+  it('generates the expected alt when passed a Figure with multiple sources of alt text and an image', () => {
+    render(<>
+      {contentToJsx({
+        type: 'Figure',
+        label: 'I am a label',
+        caption: 'I am a caption',
+        content: {
+          type: 'ImageObject',
+          contentUrl: 'https://placekitten.com/500/300',
+          meta: {
+            inline: false,
+          },
+        },
+      })}
+    </>);
+
+    const imgElement = document.querySelector('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a caption');
+  });
+
   it('generates the expected html when passed a ImageObject', () => {
     const result = contentToJsx({
       type: 'ImageObject',

--- a/src/utils/content-to-jsx.test.tsx
+++ b/src/utils/content-to-jsx.test.tsx
@@ -121,7 +121,9 @@ describe('Content to JSX', () => {
     expect(result).toStrictEqual(
       <Figure content="I am a figure" id='id'
         caption='I am a caption'
-        label='I am a label' />,
+        label='I am a label'
+        captionAriaHidden={true}
+        labelAriaHidden={false} />,
     );
   });
 
@@ -144,6 +146,9 @@ describe('Content to JSX', () => {
     const imgElement = document.querySelector('img');
     expect(imgElement).toBeInTheDocument();
     expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a caption');
+    const captionElement = document.querySelector('figcaption');
+    expect(captionElement).toBeInTheDocument();
+    expect(captionElement?.getAttribute('aria-hidden')).toStrictEqual('true');
   });
 
   it('generates the expected alt when passed a Figure with a label and an image', () => {
@@ -164,6 +169,9 @@ describe('Content to JSX', () => {
     const imgElement = document.querySelector('img');
     expect(imgElement).toBeInTheDocument();
     expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a label');
+    const labelElement = document.querySelector('label');
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement?.getAttribute('aria-hidden')).toStrictEqual('true');
   });
 
   it('generates the expected alt when passed a Figure with multiple sources of alt text and an image', () => {
@@ -185,6 +193,12 @@ describe('Content to JSX', () => {
     const imgElement = document.querySelector('img');
     expect(imgElement).toBeInTheDocument();
     expect(imgElement?.getAttribute('alt')).toStrictEqual('I am a caption');
+    const captionElement = document.querySelector('figcaption');
+    expect(captionElement).toBeInTheDocument();
+    expect(captionElement?.getAttribute('aria-hidden')).toStrictEqual('true');
+    const labelElement = document.querySelector('label');
+    expect(labelElement).toBeInTheDocument();
+    expect(labelElement?.getAttribute('aria-hidden')).toBeNull();
   });
 
   it('generates the expected html when passed a ImageObject', () => {

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -1,5 +1,5 @@
 import { Fragment, JSX } from 'react';
-import { Content } from '../types';
+import { Content, FigureContent } from '../types';
 import { Heading } from '../components/atoms/heading/heading';
 import { generateImageUrl } from './generate-image-url';
 import { Figure } from '../components/atoms/figure/figure';
@@ -11,6 +11,21 @@ type Options = {
   maxHeadingLevel?: 1 | 2 | 3 | 4 | 5 | 6,
   imgInfo?: Record<string, { width: number, height: number }>,
   removePictureTag?: boolean,
+  altText?: string,
+};
+
+const figureToAltText = (figure: FigureContent): string | undefined => {
+  if (figure.caption) {
+    return contentToText(figure.caption);
+  }
+  if (figure.label) {
+    return contentToText(figure.label);
+  }
+  if (figure.id) {
+    return figure.id;
+  }
+
+  return undefined;
 };
 
 export const contentToJsx = (content?: Content, options?: Options, index?: number): JSXContent => {
@@ -81,8 +96,15 @@ export const contentToJsx = (content?: Content, options?: Options, index?: numbe
       return <sub key={index}>{ contentToJsx(content.content, options)}</sub>;
     case 'Date':
       return <time key={index}>{ contentToJsx(content.content, options)}</time>;
-    case 'Figure':
-      return <Figure key={index} id={content.id} caption={contentToJsx(content.caption, { ...options, maxHeadingLevel: 4 })} label={content.label} content={contentToJsx(content.content, options)} />;
+    case 'Figure': {
+      return <Figure
+        key={index}
+        id={content.id}
+        caption={contentToJsx(content.caption, { ...options, maxHeadingLevel: 4 })}
+        label={content.label}
+        content={contentToJsx(content.content, { ...options, altText: figureToAltText(content) })}
+      />;
+    }
     case 'ImageObject':
       if (!content.contentUrl) {
         return '';
@@ -100,7 +122,8 @@ export const contentToJsx = (content?: Content, options?: Options, index?: numbe
         // eslint-disable-next-line @next/next/no-img-element
         const image = <img loading="lazy" {...(content.meta.inline ?
           { className: 'inline-image' } : {})}
-          src={generateImageUrl(content.contentUrl)} alt=""
+          src={generateImageUrl(content.contentUrl)}
+          alt={ options?.altText ?? '' }
           {...additionalProps}
         />;
 

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -1,5 +1,5 @@
 import { Fragment, JSX } from 'react';
-import { Content, FigureContent } from '../types';
+import { Content } from '../types';
 import { Heading } from '../components/atoms/heading/heading';
 import { generateImageUrl } from './generate-image-url';
 import { Figure } from '../components/atoms/figure/figure';
@@ -12,16 +12,6 @@ type Options = {
   imgInfo?: Record<string, { width: number, height: number }>,
   removePictureTag?: boolean,
   altText?: string,
-};
-
-const figureToAltText = (figure: FigureContent): string | undefined => {
-  if (figure.caption) {
-    return contentToText(figure.caption);
-  }
-  if (figure.label) {
-    return contentToText(figure.label);
-  }
-  return undefined;
 };
 
 export const contentToJsx = (content?: Content, options?: Options, index?: number): JSXContent => {
@@ -93,12 +83,13 @@ export const contentToJsx = (content?: Content, options?: Options, index?: numbe
     case 'Date':
       return <time key={index}>{ contentToJsx(content.content, options)}</time>;
     case 'Figure': {
+      const altText = contentToText(content.caption ?? content.label ?? undefined);
       return <Figure
         key={index}
         id={content.id}
         caption={contentToJsx(content.caption, { ...options, maxHeadingLevel: 4 })}
         label={content.label}
-        content={contentToJsx(content.content, { ...options, altText: figureToAltText(content) })}
+        content={contentToJsx(content.content, { ...options, altText })}
       />;
     }
     case 'ImageObject':

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -21,10 +21,6 @@ const figureToAltText = (figure: FigureContent): string | undefined => {
   if (figure.label) {
     return contentToText(figure.label);
   }
-  if (figure.id) {
-    return figure.id;
-  }
-
   return undefined;
 };
 

--- a/src/utils/content-to-jsx.tsx
+++ b/src/utils/content-to-jsx.tsx
@@ -84,11 +84,15 @@ export const contentToJsx = (content?: Content, options?: Options, index?: numbe
       return <time key={index}>{ contentToJsx(content.content, options)}</time>;
     case 'Figure': {
       const altText = contentToText(content.caption ?? content.label ?? undefined);
+      const captionAriaHidden = !!content.caption;
+      const labelAriaHidden = !content.caption && !!content.label;
       return <Figure
         key={index}
         id={content.id}
         caption={contentToJsx(content.caption, { ...options, maxHeadingLevel: 4 })}
+        captionAriaHidden={captionAriaHidden}
         label={content.label}
+        labelAriaHidden={labelAriaHidden}
         content={contentToJsx(content.content, { ...options, altText })}
       />;
     }

--- a/src/utils/content-to-text.test.ts
+++ b/src/utils/content-to-text.test.ts
@@ -21,12 +21,6 @@ describe('Content to Text', () => {
   it('generates nothing when unsupported content types are passed', () => {
     const result = contentToText([
       {
-        type: 'Heading',
-        depth: 1,
-        content: 'heading',
-        id: 'h1',
-      },
-      {
         type: 'Cite',
         content: 'I am a citation',
         target: 'target',
@@ -99,10 +93,25 @@ describe('Content to Text', () => {
     expect(result).toStrictEqual('I am a subscript');
   });
 
+  it('generates the expected text when passed a Heading', () => {
+    const result = contentToText({
+      type: 'Heading',
+      depth: 1,
+      content: 'heading',
+      id: 'h1',
+    });
+
+    expect(result).toStrictEqual('heading');
+  });
+
   it('allows an array of arrays to be generated', () => {
     const result = contentToText([
       [{
-        type: 'Heading', depth: 1, content: 'heading', id: 'h1',
+        type: 'Figure',
+        content: 'I am a figure',
+        caption: 'I am a caption',
+        label: 'I am a label',
+        id: 'id',
       }],
     ]);
 

--- a/src/utils/content-to-text.ts
+++ b/src/utils/content-to-text.ts
@@ -1,6 +1,6 @@
 import { Content } from '../types';
 
-export const contentToText = (content: Content): string => {
+export const contentToText = (content?: Content): string => {
   if (typeof content === 'undefined') {
     return '';
   }

--- a/src/utils/content-to-text.ts
+++ b/src/utils/content-to-text.ts
@@ -12,6 +12,7 @@ export const contentToText = (content: Content): string => {
     return content.map((part) => contentToText(part)).join('');
   }
   switch (content.type) {
+    case 'Heading':
     case 'Paragraph':
     case 'Emphasis':
     case 'Strong':


### PR DESCRIPTION
When building a figure, pass down some alt text based on content we already have:
- caption
- label

Use this for any sub images.

Assumption (on my part): 
- only one image per figure and all images should have the alt text
- aria-hidden is added to `figcaption` or `label` depending on which is used for alt text, but we assume that a figure has an image

Limitations / todo: 

- `contentToText()` seemed to deliberately exclude headings from the content. This puts it back in, but the original reasons are unclear and need investigation
- it is possible that content that has a figure without an image inside would aria-hidden the caption/label from screenreaders
- Does this affect Coko rendering at all?

Result:
An example figure has a label of "Figure 1" and a caption of "(A) FISH analyses of G4C2 repeat RNA in the salivary glands of fly larvae expressing both (G4C2)89 and either FUS or FUS-RRMmut using two copies of the GMR-Gal4 driver (red: G4C2 RNA; blue [DAPI]: nuclei). Arrowheads indicate RNA foci. Scale bar: 20 μm.".

Old: 
- "Figure 1"
- Nothing
- "(A) FISH analyses of G4C2 repeat RNA in the salivary glands of fly larvae expressing both (G4C2)89 and either FUS or FUS-RRMmut using two copies of the GMR-Gal4 driver (red: G4C2 RNA; blue [DAPI]: nuclei). Arrowheads indicate RNA foci. Scale bar: 20 μm."

New:
- "Figure 1"
- "(A) FISH analyses of G4C2 repeat RNA in the salivary glands of fly larvae expressing both (G4C2)89 and either FUS or FUS-RRMmut using two copies of the GMR-Gal4 driver (red: G4C2 RNA; blue [DAPI]: nuclei). Arrowheads indicate RNA foci. Scale bar: 20 μm."
- Nothing
