### PR TITLE
Remove superflous volume mounts that stop the browser tests running without having run the full suite beforehand

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,20 @@ jobs:
         run: yarn test
       - name: Production build
         run: yarn build
+  test-browsertests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read .nvmrc
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
+        id: nvm
+      - name: Use Node.js (.nvmrc)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          cache: yarn
+      - name: yarn install
+        run: yarn
       - name: Install operating system dependencies
         run: |
           yarn playwright install
@@ -50,7 +64,7 @@ jobs:
       - name: Take down browser test stack
         run: docker compose -f docker-compose.browsertest.yaml down
   build-and-push:
-    needs: [test]
+    needs: [test, test-browsertests]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:

--- a/docker-compose.browsertest.yaml
+++ b/docker-compose.browsertest.yaml
@@ -15,9 +15,6 @@ services:
       API_SERVER: http://api:3000
     ports:
     - 3001:3000
-    volumes:
-    - ./:/opt/epp-client/
-    - node_modules:/opt/epp-client/node_modules
 
   # expose API and client via proxy
   api:
@@ -28,4 +25,3 @@ services:
 
 volumes:
   data:
-  node_modules:


### PR DESCRIPTION
With a completely clean docker, you bring up the browser test setup by running `docker compose -f docker-compose.browsertest.yaml up` on it's own. It depends on a volume being filled by running `docker compose up` first.

This removes that dependency. Also separates it to another job which reduces overall CI time by about 45s