### PR TITLE
use exitZeroOnChanges option to fail a job on unapproved changes

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -14,4 +14,3 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          exitZeroOnChanges: false

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -14,3 +14,4 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          exitZeroOnChanges: false

--- a/src/utils/mocks/content.ts
+++ b/src/utils/mocks/content.ts
@@ -13,7 +13,7 @@ export const content: Content = [
   {
     type: 'Paragraph',
     content: [
-      'Autophagy is the lysosome-based degradation system in eukaryotes essential for cellular\n                homeostasis as part of intracellular quality control and intracellular remodeling during environmental\n                adaptation (\n                ',
+      'Autpohagy is the lysosome-based degradation system in eukaryotes essential for cellular\n                homeostasis as part of intracellular quality control and intracellular remodeling during environmental\n                adaptation (\n                ',
       {
         type: 'Emphasis',
         content: [

--- a/src/utils/mocks/content.ts
+++ b/src/utils/mocks/content.ts
@@ -13,7 +13,7 @@ export const content: Content = [
   {
     type: 'Paragraph',
     content: [
-      'Autpohagy is the lysosome-based degradation system in eukaryotes essential for cellular\n                homeostasis as part of intracellular quality control and intracellular remodeling during environmental\n                adaptation (\n                ',
+      'Autophagy is the lysosome-based degradation system in eukaryotes essential for cellular\n                homeostasis as part of intracellular quality control and intracellular remodeling during environmental\n                adaptation (\n                ',
       {
         type: 'Emphasis',
         content: [


### PR DESCRIPTION
# Description

This change means that if there are changes in need of approval, the job will exit with non-zero. In other words - changes in need of approval fail the build.

The workflow for a failing commit to be approved then is:
- action run test job, fails
- follow the status to review and approve
- rerun the failing job.

With this change, we can now consider integrating with the ci workflow to stop the build on chromatic failure