### PR TITLE
Improve prod mode for changing global config between build and server start

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,7 +1,9 @@
 # overrides that make the app behave like a production build
 services:
   app:
-    command: sh -c 'yarn build; yarn start'
+    build:
+      context: .
+      target: prod
     healthcheck:
       test: ["CMD-SHELL", "sh -c 'apk add curl; curl -X POST http://app:3000/'"]
       interval: 5s


### PR DESCRIPTION
When using prod mode, it becomes impossible to test what happens in the real scenario that:
- the next build is run without any environment/config
- the server is started with environment/config

With this change we can run `yarn build` in your checkout, without config, and then restart the app (`docker compose restart app`) to see the effects

Used and testing during https://github.com/elifesciences/enhanced-preprints-client/pull/2165