### PR TITLE
References refactor

### DIFF
--- a/src/components/atoms/reference-list/reference-list.scss
+++ b/src/components/atoms/reference-list/reference-list.scss
@@ -8,21 +8,5 @@
 
 .reference-list__item {
   @include mixins.margin(24, "bottom");
-  @include typography.body-alternative();
-}
-
-.reference__title {
-  @include typography.author-list-text();
-
-  &::after {
-    content: " ";
-  }
-}
-
-.reference__doi {
-  display: block;
-}
-
-.reference__doi_link {
-  @include typography.link-text();
+  @include typography.body();
 }

--- a/src/components/atoms/reference-list/reference-list.scss
+++ b/src/components/atoms/reference-list/reference-list.scss
@@ -8,7 +8,4 @@
 
 .reference-list__item {
   @include mixins.margin(24, "bottom");
-  @include typography.body();
-
-  font-family: var(--font-family-primary);
 }

--- a/src/components/atoms/reference-list/reference-list.scss
+++ b/src/components/atoms/reference-list/reference-list.scss
@@ -9,4 +9,6 @@
 .reference-list__item {
   @include mixins.margin(24, "bottom");
   @include typography.body();
+
+  font-family: var(--font-family-primary);
 }

--- a/src/components/atoms/reference-list/reference-list.test.tsx
+++ b/src/components/atoms/reference-list/reference-list.test.tsx
@@ -6,6 +6,7 @@ describe('ReferenceList', () => {
   it('should render all the references passed in as a prop', () => {
     render(<ReferenceList references={references} />);
 
+    expect(document.querySelectorAll('.reference-list__item')).toHaveLength(5);
     expect(screen.getByText('Resurgent Na currents in four classes of neurons of the cerebellum')).toBeInTheDocument();
     expect(screen.getByText('The Role of Estrogen Receptors in Cardiovascular Disease')).toBeInTheDocument();
     expect(screen.getByText('The Theory of Everything')).toBeInTheDocument();

--- a/src/components/atoms/reference-list/reference-list.tsx
+++ b/src/components/atoms/reference-list/reference-list.tsx
@@ -7,7 +7,11 @@ export const ReferenceList = ({ references }: { references: ReferenceData[] }) =
   <section>
     <Heading id="references" headingLevel={1} content="References" />
     <ul className="reference-list">
-      {references.map((reference, index) => <Reference key={index} reference={reference} isReferenceList={true} />)}
+      {references.map((reference, index) => (
+        <li key={index} className="reference-list__item" id={reference.id}>
+          <Reference reference={reference} />
+        </li>
+      ))}
     </ul>
   </section>
 );

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -7,6 +7,10 @@
 
   font-family: var(--font-family-primary);
   font-weight: bold;
+
+  &::after {
+    content: " ";
+  }
 }
 
 .reference__title--link {

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -58,10 +58,11 @@
   @include typography.body-small();
 
   color: var(--color-text-secondary);
+  display: block;
 }
 
 .reference__doi_link {
-  @include typography.body-small();
+  @include typography.link-text();
 
   color: var(--color-primary);
   font-weight: normal;

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -66,8 +66,13 @@
 }
 
 .reference__doi_link {
-  @include typography.link-text();
+  @include typography.body-small();
 
   color: var(--color-primary);
-  font-weight: normal;
+  font-weight: 600;
+  text-decoration: none;
+
+  :visited {
+    color: var(--color-primary);
+  }
 }

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -69,7 +69,6 @@
   @include typography.body-small();
 
   color: var(--color-primary);
-  font-weight: 600;
   text-decoration: none;
 
   :visited {

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -21,13 +21,6 @@
   }
 }
 
-.reference {
-  @include mixins.margin(24, "bottom");
-  @include typography.body();
-
-  font-family: var(--font-family-primary);
-}
-
 .reference__label {
   &::after {
     content: " ";

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -2,7 +2,14 @@
 @use "../../../sass/settings";
 @use "../../../sass/typography";
 
+%reference {
+  @include typography.body();
+
+  font-family: var(--font-family-primary);
+}
+
 .reference__title {
+  @extend %reference;
   @include typography.body();
 
   font-family: var(--font-family-primary);
@@ -26,12 +33,16 @@
 }
 
 .reference__label {
+  @extend %reference;
+
   &::after {
     content: " ";
   }
 }
 
 .reference__authors_list {
+  @extend %reference;
+
   display: inline;
   list-style: none;
   padding: 0;
@@ -58,6 +69,7 @@
 }
 
 .reference__doi {
+  @extend %reference;
   @include mixins.margin(12 0 36);
   @include typography.body-small();
 

--- a/src/components/atoms/reference/reference.scss
+++ b/src/components/atoms/reference/reference.scss
@@ -32,6 +32,10 @@
   }
 }
 
+.reference__origin {
+  @extend %reference;
+}
+
 .reference__label {
   @extend %reference;
 
@@ -60,12 +64,16 @@
   }
 }
 
-.reference__authors_list_suffix::before {
-  content: "(";
-}
+.reference__authors_list_suffix {
+  @extend %reference;
 
-.reference__authors_list_suffix::after {
-  content: ") ";
+  &::before {
+    content: "(";
+  }
+
+  &::after {
+    content: ") ";
+  }
 }
 
 .reference__doi {

--- a/src/components/atoms/reference/reference.stories.tsx
+++ b/src/components/atoms/reference/reference.stories.tsx
@@ -25,6 +25,5 @@ export const ReferenceGroupStory: Story = {
 export const ReferenceIsReferenceList: Story = {
   args: {
     reference: references[0],
-    isReferenceList: true,
   },
 };

--- a/src/components/atoms/reference/reference.stories.tsx
+++ b/src/components/atoms/reference/reference.stories.tsx
@@ -21,9 +21,3 @@ export const ReferenceGroupStory: Story = {
     reference: references[2],
   },
 };
-
-export const ReferenceIsReferenceList: Story = {
-  args: {
-    reference: references[0],
-  },
-};

--- a/src/components/atoms/reference/reference.test.tsx
+++ b/src/components/atoms/reference/reference.test.tsx
@@ -12,42 +12,35 @@ describe('Reference', () => {
     url: 'http://www.google.com',
   };
   it('should render all the references passed in as a prop', () => {
-    render(<Reference reference={references[0]} isReferenceList={false} />);
+    render(<Reference reference={references[0]} />);
 
     expect(screen.getByText('Resurgent Na currents in four classes of neurons of the cerebellum')).toBeInTheDocument();
     expect(screen.getByText('Afshari FS')).toBeInTheDocument();
     expect(screen.getByText('1847')).toBeInTheDocument();
     expect(screen.getByText('J. Neurophysiol')).toBeInTheDocument();
-    expect(screen.getByText('Resurgent Na currents in four classes of neurons of the cerebellum').parentElement?.parentElement?.id).toStrictEqual('c1');
     expect(screen.getByText('2843', { exact: false })).toBeInTheDocument();
   });
 
   it('should render the title as a link if URL is present', () => {
-    render(<Reference reference={ref} isReferenceList={false} />);
+    render(<Reference reference={ref} />);
 
     expect(screen.getByText('Title')).toHaveAttribute('href', 'http://www.google.com');
   });
 
   it('should be wrapped in a div if isReferenceList is false', () => {
-    render(<Reference reference={references[0]} isReferenceList={false} />);
+    render(<Reference reference={references[0]} />);
 
     expect(screen.getByText(references[0].title).parentElement?.parentElement?.tagName).toStrictEqual('DIV');
   });
 
-  it('should not render the label if the reference has one', () => {
-    render(<Reference reference={references[0]} isReferenceList={false} />);
-
-    expect(screen.queryByText('1.')).not.toBeInTheDocument();
-  });
-
   it('should not render an end page if the start page is undefined', () => {
-    render(<Reference reference={{ ...references[0], pageStart: undefined }} isReferenceList={false} />);
+    render(<Reference reference={{ ...references[0], pageStart: undefined }} />);
 
     expect(screen.queryByText('2843', { exact: false })).not.toBeInTheDocument();
   });
 
   it('renders the name when an organisation is the author', () => {
-    render(<Reference reference={references[2]} isReferenceList={false} />);
+    render(<Reference reference={references[2]} />);
 
     expect(screen.getByText('the Brain Interfacing Laboratory')).toBeInTheDocument();
   });
@@ -89,48 +82,40 @@ describe('Reference', () => {
       title: 'Environmental Physiology and Biochemistry of Insects',
       ...referenceWithPublisher,
     } as ReferenceData;
-    render(<Reference reference={prepareReference} isReferenceList={false} />);
+    render(<Reference reference={prepareReference} />);
 
     expect(screen.getByText(expectedJournalAndPublisher)).toBeInTheDocument();
   });
 
-  describe('inside a reference list', () => {
-    it('should be wrapped in an li if isReferenceList is true', () => {
-      render(<Reference reference={references[0]} isReferenceList={true} />);
+  it('should wrap doi in link', () => {
+    render(<Reference reference={references[0]} />);
 
-      expect(document.getElementById('c1')?.tagName).toStrictEqual('LI');
-    });
+    expect(screen.getByText('https://doi.org/', { exact: false }).tagName).toStrictEqual('A');
+    expect(screen.getByText('https://doi.org/', { exact: false })).toHaveAttribute('href', 'https://doi.org/10.7554/eLife.16135');
+  });
 
-    it('should wrap doi in link if isReferenceList is true', () => {
-      render(<Reference reference={references[0]} isReferenceList={true} />);
+  it('should render the label if the reference has one', () => {
+    render(<Reference reference={references[0]} />);
 
-      expect(screen.getByText('https://doi.org/', { exact: false }).tagName).toStrictEqual('A');
-      expect(screen.getByText('https://doi.org/', { exact: false })).toHaveAttribute('href', 'https://doi.org/10.7554/eLife.16135');
-    });
+    expect(screen.getByText('1.')).toBeInTheDocument();
+  });
 
-    it('should render the label if the reference has one', () => {
-      render(<Reference reference={references[0]} isReferenceList={true} />);
+  it('should display URL link if present', () => {
+    render(<Reference reference={ref} />);
 
-      expect(screen.getByText('1.')).toBeInTheDocument();
-    });
+    expect(screen.getByText('http://www.google.com').tagName).toStrictEqual('A');
+    expect(screen.getByText('http://www.google.com')).toHaveAttribute('href', 'http://www.google.com');
+  });
 
-    it('should display URL link if present', () => {
-      render(<Reference reference={ref} isReferenceList={true} />);
+  it('should render the reference name correctly if givenNames is undefined', () => {
+    render(<Reference reference={references[0]} />);
 
-      expect(screen.getByText('http://www.google.com').tagName).toStrictEqual('A');
-      expect(screen.getByText('http://www.google.com')).toHaveAttribute('href', 'http://www.google.com');
-    });
+    expect(screen.getByText('NoGiven').textContent).toStrictEqual('NoGiven');
+  });
 
-    it('should render the reference name correctly if givenNames is undefined', () => {
-      render(<Reference reference={references[0]} isReferenceList={true} />);
+  it('should render without a publishedYear', () => {
+    render(<Reference reference={references[3]} />);
 
-      expect(screen.getByText('NoGiven').textContent).toStrictEqual('NoGiven');
-    });
-
-    it('should render without a publishedYear', () => {
-      render(<Reference reference={references[3]} isReferenceList={true} />);
-
-      expect(document.getElementById('c4')?.textContent).toContain('Given BugsResurgent');
-    });
+    expect(screen.getByText('Given Bugs', { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -8,7 +8,7 @@ type ReferenceBodyProps = {
 
 const formatName = (author: Author) => `${author.familyNames ? author.familyNames?.join(' ') : ''} ${author.givenNames ? author.givenNames?.join(' ') : ''}`.trim();
 
-export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceBodyProps) => {
+function prepareReference(reference: ReferenceData) {
   const referenceJournal = reference.isPartOf?.isPartOf?.isPartOf?.name ?? reference.isPartOf?.isPartOf?.name ?? reference.isPartOf?.name;
   const referencePublisher = reference.publisher;
   const referenceVolume = reference.isPartOf?.isPartOf?.volumeNumber ?? reference.isPartOf?.volumeNumber;
@@ -16,6 +16,21 @@ export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceB
   const year = reference.datePublished ? new Date(typeof reference.datePublished === 'string' ? reference.datePublished : reference.datePublished.value).getUTCFullYear() : undefined;
   const linkText = doiIdentifier ? `https://doi.org/${doiIdentifier.value}` : reference.url;
   const linkRef = doiIdentifier ? `https://doi.org/${doiIdentifier.value}` : reference.url;
+
+  return {
+    referenceJournal,
+    referencePublisher,
+    referenceVolume,
+    year,
+    linkText,
+    linkRef,
+  };
+}
+
+export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceBodyProps) => {
+  const {
+    referenceJournal, referencePublisher, referenceVolume, year, linkText, linkRef,
+  } = prepareReference(reference);
 
   return (
     <>

--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -3,7 +3,6 @@ import './reference.scss';
 
 type ReferenceBodyProps = {
   reference: ReferenceData,
-  isReferenceList: boolean
 };
 
 const formatName = (author: Author) => `${author.familyNames ? author.familyNames?.join(' ') : ''} ${author.givenNames ? author.givenNames?.join(' ') : ''}`.trim();
@@ -27,14 +26,14 @@ function prepareReference(reference: ReferenceData) {
   };
 }
 
-export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceBodyProps) => {
+export const Reference = ({ reference }: ReferenceBodyProps) => {
   const {
     referenceJournal, referencePublisher, referenceVolume, year, linkText, linkRef,
   } = prepareReference(reference);
 
   return (
     <>
-      { (isReferenceList && reference.meta?.label) && <span className="reference__label">{reference.meta.label}</span>}
+      { reference.meta?.label && <span className="reference__label">{reference.meta.label}</span>}
       <ol className="reference__authors_list">
         {reference.authors.map((author, index) => (
           <li key={index} className="reference__author">
@@ -43,7 +42,7 @@ export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceB
         ))}
       </ol>
       { year && <span className="reference__authors_list_suffix">{year}</span> }
-      <span className="reference__title">{linkRef ? <a className="reference__title--link" href={linkRef}>{reference.title}</a> : reference.title}</span>
+      <span className="referenfce__title">{linkRef ? <a className="reference__title--link" href={linkRef}>{reference.title}</a> : reference.title}</span>
       <span className="reference__origin">
         {referenceJournal && <><i>{referenceJournal}</i> </>}
         {referencePublisher && <>{referencePublisher.address && <>{referencePublisher.address.addressLocality}: </>}{referencePublisher.name} </>}
@@ -51,18 +50,11 @@ export const ReferenceBody = ({ reference, isReferenceList = false }: ReferenceB
         {reference.pageStart && `:${reference.pageStart}${reference.pageEnd !== undefined ? `–${reference.pageEnd}` : ''}`}
       </span>
       {(linkRef) && <span className="reference__doi">
-        {isReferenceList ?
-          <a href={linkRef} className="reference__doi_link">
-            {linkText}
-          </a>
-          : linkRef}
+        <a href={linkRef} className="reference__doi_link">
+          {linkText}
+        </a>
         </span>
       }
     </>
   );
 };
-
-export const Reference = ({ reference, isReferenceList = false }: { reference: ReferenceData, isReferenceList: boolean }) => (isReferenceList ?
-  <li className="reference" id={reference.id}>{ReferenceBody({ reference, isReferenceList })}</li> :
-  <div className="reference" id={reference.id}>{ReferenceBody({ reference, isReferenceList })}</div>
-);

--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -42,7 +42,7 @@ export const Reference = ({ reference }: ReferenceBodyProps) => {
         ))}
       </ol>
       { year && <span className="reference__authors_list_suffix">{year}</span> }
-      <span className="referenfce__title">{linkRef ? <a className="reference__title--link" href={linkRef}>{reference.title}</a> : reference.title}</span>
+      <span className="reference__title">{linkRef ? <a className="reference__title--link" href={linkRef}>{reference.title}</a> : reference.title}</span>
       <span className="reference__origin">
         {referenceJournal && <><i>{referenceJournal}</i> </>}
         {referencePublisher && <>{referencePublisher.address && <>{referencePublisher.address.addressLocality}: </>}{referencePublisher.name} </>}


### PR DESCRIPTION
This purpose of this branch is to refactor the references and reference-list components to remove the coupling between the two. The styling in particular is in particular very closely coupled and some of the styles for the reference were only coming from reference-list.