### PR TITLE
make meta.yearPulished the default reference year value

### DIFF
--- a/src/components/atoms/reference-list/reference-list.test.tsx
+++ b/src/components/atoms/reference-list/reference-list.test.tsx
@@ -15,9 +15,9 @@ describe('ReferenceList', () => {
     expect(screen.getByText('Agopian J')).toBeInTheDocument();
     expect(screen.getByText('the Brain Interfacing Laboratory')).toBeInTheDocument();
 
-    expect(screen.getByText('1847')).toBeInTheDocument();
-    expect(screen.getByText('2020')).toBeInTheDocument();
-    expect(screen.getByText('2021')).toBeInTheDocument();
+    expect(screen.getByText('2019a')).toBeInTheDocument();
+    expect(screen.getByText('2019b')).toBeInTheDocument();
+    expect(screen.getByText('2019c')).toBeInTheDocument();
 
     expect(screen.getByText('Int J Mol Sci')).toBeInTheDocument();
     expect(screen.getByText('J. Neurophysiol')).toBeInTheDocument();

--- a/src/components/atoms/reference/reference.test.tsx
+++ b/src/components/atoms/reference/reference.test.tsx
@@ -16,7 +16,7 @@ describe('Reference', () => {
 
     expect(screen.getByText('Resurgent Na currents in four classes of neurons of the cerebellum')).toBeInTheDocument();
     expect(screen.getByText('Afshari FS')).toBeInTheDocument();
-    expect(screen.getByText('1847')).toBeInTheDocument();
+    expect(screen.getByText('2019a')).toBeInTheDocument();
     expect(screen.getByText('J. Neurophysiol')).toBeInTheDocument();
     expect(screen.getByText('2843', { exact: false })).toBeInTheDocument();
   });
@@ -111,6 +111,18 @@ describe('Reference', () => {
     render(<Reference reference={references[0]} />);
 
     expect(screen.getByText('NoGiven').textContent).toStrictEqual('NoGiven');
+  });
+
+  it('should render the publishedYear from the meta property if present', () => {
+    render(<Reference reference={references[0]} />);
+
+    expect(screen.getByText('2019a')).toBeInTheDocument();
+  });
+
+  it('should render the year from the datePublished property if not in meta', () => {
+    render(<Reference reference={references[4]} />);
+
+    expect(screen.getByText('1985')).toBeInTheDocument();
   });
 
   it('should render without a publishedYear', () => {

--- a/src/components/atoms/reference/reference.tsx
+++ b/src/components/atoms/reference/reference.tsx
@@ -12,7 +12,11 @@ function prepareReference(reference: ReferenceData) {
   const referencePublisher = reference.publisher;
   const referenceVolume = reference.isPartOf?.isPartOf?.volumeNumber ?? reference.isPartOf?.volumeNumber;
   const doiIdentifier = reference.identifiers?.find((identifier) => identifier.name === 'doi');
-  const year = reference.datePublished ? new Date(typeof reference.datePublished === 'string' ? reference.datePublished : reference.datePublished.value).getUTCFullYear() : undefined;
+  const year = reference.meta?.yearPublished ?? (
+    reference.datePublished ?
+      new Date(typeof reference.datePublished === 'string' ? reference.datePublished : reference.datePublished.value).getUTCFullYear() :
+      undefined
+  );
   const linkText = doiIdentifier ? `https://doi.org/${doiIdentifier.value}` : reference.url;
   const linkRef = doiIdentifier ? `https://doi.org/${doiIdentifier.value}` : reference.url;
 

--- a/src/utils/mocks/references.ts
+++ b/src/utils/mocks/references.ts
@@ -90,7 +90,7 @@ export const references: Reference[] = [
       },
     ],
     meta: {
-      yearPublished: '2019b',
+      yearPublished: '2019c',
       label: '2.',
     },
   },
@@ -113,7 +113,7 @@ export const references: Reference[] = [
       },
     ],
     meta: {
-      yearPublished: '2019a',
+      yearPublished: '2019d',
       label: '1.',
     },
   },


### PR DESCRIPTION
related to this issue: https://github.com/orgs/elifesciences/projects/11/views/4?pane=issue&itemId=38344522&issue=elifesciences%7Cenhanced-preprints-issues%7C815